### PR TITLE
Should fix Issue #3 and add an export test

### DIFF
--- a/edsl/results/ResultsExportMixin.py
+++ b/edsl/results/ResultsExportMixin.py
@@ -50,16 +50,16 @@ class ResultsExportMixin:
                 writer.writerow(header)
                 writer.writerows(rows)
 
-            if download_link:
-                import base64
-                from IPython.display import HTML, display
+                if download_link:
+                    import base64
+                    from IPython.display import HTML, display
 
-                csv_file = output.getvalue()
-                b64 = base64.b64encode(csv_file.encode()).decode()
-                download_link = f'<a href="data:file/csv;base64,{b64}" download="my_data.csv">Download CSV file</a>'
-                display(HTML(download_link))
-            else:
-                return output.getvalue()
+                    csv_file = output.getvalue()
+                    b64 = base64.b64encode(csv_file.encode()).decode()
+                    download_link = f'<a href="data:file/csv;base64,{b64}" download="my_data.csv">Download CSV file</a>'
+                    display(HTML(download_link))
+                else:
+                    return output.getvalue()
         else:
             return self.select().to_csv(
                 filename, remove_prefix=remove_prefix, download_link=download_link

--- a/tests/results/test_Results.py
+++ b/tests/results/test_Results.py
@@ -11,6 +11,15 @@ class TestResults(unittest.TestCase):
     def test_instance(self):
         self.assertIsInstance(self.example_results, Results)
 
+    def test_csv_export(self):
+        # Just prints to screen
+        csv = self.example_results.to_csv()
+        self.assertIsInstance(csv, str)
+        self.assertIn("how_feeling", csv)
+        # Saves the file
+        csv = self.example_results.to_csv(filename="test.csv")
+        self.assertIsNone(csv)
+
     # def test_original_data_preserved(self):
     #     original_data = self.example_results.original_data
     #     self.example_results.append({"test": "data"})


### PR DESCRIPTION
The issue was that if a filename was passed, it was still executing the code for the "if download_link" block, which should have only been run if a filename was not passed. 

I also added a test that can catch this original error and I confirmed that the fix addresses the issue. 