### PR TITLE
Vscode settings in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,29 @@
+# Data files
 *csv
 *db
 *gz
 *json
 *txt
 !edsl/utilities/data/*.json
-dist
+!.vscode/settings.json
+# Docs
 docs/_build/
-htmlcov
-.backups
-.coverage
-.DS_Store
+# Dotenv
 .env
+# Jupyter notebook files
 .ipynb_checkpoints/
+# MacOS files
+.DS_Store
+# Miscelannea
+.backups
+# MyPy files
 .mypy_cache
-.pytest_cache
-.venv
+# Packaging files
+dist
+# Testing files
 __pycache__
+.coverage
+.pytest_cache
+htmlcov
+# Virtual environment files
+.venv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "[python]": {
+      "editor.formatOnSave": true,
+      "editor.codeActionsOnSave": {
+        "source.fixAll": true
+      },
+      "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.testing.pytestArgs": ["tests"],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+  }


### PR DESCRIPTION
This PR adds a .vscode/settings.json in the repo that ensures the same code formatting (black) is applied on all devs machines (provided they use vscode)