### PR TITLE
Lm refactor

### DIFF
--- a/edsl/language_models/LanguageModel.py
+++ b/edsl/language_models/LanguageModel.py
@@ -10,7 +10,7 @@ from edsl.exceptions import LanguageModelResponseNotJSONError
 from edsl.language_models.schemas import model_prices
 from edsl.trackers.TrackerAPI import TrackerAPI
 
-from edsl.utilities import repair_json
+# from edsl.utilities import repair_json
 
 from edsl.language_models.repair import repair
 
@@ -58,7 +58,9 @@ class LanguageModel(ABC):
         return response
 
     def get_raw_response(self, prompt: str, system_prompt: str = "") -> dict[str, Any]:
-        """Calls the LLM's API and returns the API response. If self.use_cache is True, then attempts to retrieve the response from the database; if not in the DB, calls the LLM and writes the response to the DB."""
+        """Calls the LLM's API and returns the API response.
+        If self.use_cache is True, then attempts to retrieve the response from the database;
+        if not in the DB, calls the LLM and writes the response to the DB."""
         start_time = time.time()
 
         if not self.use_cache:
@@ -151,14 +153,9 @@ class LanguageModel(ABC):
     @classmethod
     def from_dict(cls, data: dict) -> Type[LanguageModel]:
         """Converts dictionary to a LanguageModel child instance."""
-        if data["model"] == "gpt-3.5-turbo":
-            from edsl.language_models import LanguageModelOpenAIThreeFiveTurbo
+        from edsl.language_models.registry import get_model_class
 
-            model_class = LanguageModelOpenAIThreeFiveTurbo
-        if data["model"] == "gpt-4":
-            from edsl.language_models import LanguageModelOpenAIFour
-
-            model_class = LanguageModelOpenAIFour
+        model_class = get_model_class(data["model"])
         data["use_cache"] = True
         return model_class(**data)
 

--- a/edsl/language_models/LanguageModel.py
+++ b/edsl/language_models/LanguageModel.py
@@ -9,7 +9,10 @@ from edsl.data import CRUDOperations, CRUD
 from edsl.exceptions import LanguageModelResponseNotJSONError
 from edsl.language_models.schemas import model_prices
 from edsl.trackers.TrackerAPI import TrackerAPI
+
 from edsl.utilities import repair_json
+
+from edsl.language_models.repair import repair
 
 
 class LanguageModel(ABC):
@@ -43,87 +46,67 @@ class LanguageModel(ABC):
         """Parses the API response and returns the response text."""
         raise NotImplementedError
 
-    def get_raw_response(self, prompt: str, system_prompt: str = "") -> dict[str, Any]:
-        """Calls the LLM's API and returns the API response. If self.use_cache is True, then attempts to retrieve the response from the database; if not in the DB, calls the LLM and writes the response to the DB."""
-        start_time = time.time()
-
-        # called without cache
-        if not self.use_cache:
-            response = self.execute_model_call(prompt, system_prompt)
-            with self.lock:
-                response["cached_response"] = False
-
-        # called with cache
-        if self.use_cache:
-            # attempt to get cached response from DB
-            cached_response = self.crud.get_LLMOutputData(
-                model=str(self.model),
-                parameters=str(self.parameters),
-                system_prompt=system_prompt,
-                prompt=prompt,
-            )
-            # if cached response in DB, load
-            if cached_response:
-                response = json.loads(cached_response)
-                with self.lock:
-                    response["cached_response"] = True
-            # otherwise, call model and save response to DB
-            else:
-                response = self.execute_model_call(prompt, system_prompt)
-                try:
-                    output = json.dumps(response)
-                except json.JSONDecodeError:
-                    raise LanguageModelResponseNotJSONError
-                self.crud.write_LLMOutputData(
-                    model=str(self.model),
-                    parameters=str(self.parameters),
-                    system_prompt=system_prompt,
-                    prompt=prompt,
-                    output=output,
-                )
-                with self.lock:
-                    response["cached_response"] = False
-
-        # record usage details
+    def _update_response_with_tracking(
+        self, response, start_time, cached_response=False
+    ):
         end_time = time.time()
         response["elapsed_time"] = end_time - start_time
         response["timestamp"] = end_time
         self._post_tracker_event(response)
-
+        with self.lock:
+            response["cached_response"] = cached_response
         return response
+
+    def get_raw_response(self, prompt: str, system_prompt: str = "") -> dict[str, Any]:
+        """Calls the LLM's API and returns the API response. If self.use_cache is True, then attempts to retrieve the response from the database; if not in the DB, calls the LLM and writes the response to the DB."""
+        start_time = time.time()
+
+        if not self.use_cache:
+            response = self.execute_model_call(prompt, system_prompt)
+            return self._update_response_with_tracking(response, start_time, False)
+
+        cached_response = self.crud.get_LLMOutputData(
+            model=str(self.model),
+            parameters=str(self.parameters),
+            system_prompt=system_prompt,
+            prompt=prompt,
+        )
+
+        if cached_response:
+            response = json.loads(cached_response)
+            cache_used = True
+        else:
+            response = self.execute_model_call(prompt, system_prompt)
+            self._save_response_to_db(prompt, system_prompt, response)
+            cache_used = False
+
+        return self._update_response_with_tracking(response, start_time, cache_used)
+
+    def _save_response_to_db(self, prompt, system_prompt, response):
+        try:
+            output = json.dumps(response)
+        except json.JSONDecodeError:
+            raise LanguageModelResponseNotJSONError
+        self.crud.write_LLMOutputData(
+            model=str(self.model),
+            parameters=str(self.parameters),
+            system_prompt=system_prompt,
+            prompt=prompt,
+            output=output,
+        )
 
     def get_response(self, prompt: str, system_prompt: str = ""):
         """Get response, parse, and return as string."""
-
-        def load_json_closure(json_repair_func: Callable) -> Callable:
-            """
-            Closure to load json, and repair if necessary.
-
-            Notes:
-            - Why this convoluted closure structure you might ask? Because it's more extensible and it captures the sequence of attemps/tranformations. We can add an LLM repair step with the best available model if the "simpler" approach of just calling repair_json doesn't work.
-            """
-            prior_strings = []
-
-            def func(json_string):
-                prior_strings.append(json_string)
-                if len(prior_strings) > 2:
-                    raise Exception(
-                        f"Could not repair json.loads. Sequence of attempts: {prior_strings}"
-                    )
-                try:
-                    dict_response = json.loads(json_string)
-                    return dict_response
-                except json.JSONDecodeError:
-                    print("Could not load. Trying to repair.")
-                    new_json = json_repair_func(json_string)
-                    return func(new_json)
-
-            return func
-
         raw_response = self.get_raw_response(prompt, system_prompt)
         response = self.parse_response(raw_response)
-        load_json = load_json_closure(repair_json)
-        return load_json(response)
+        try:
+            dict_response = json.loads(response)
+        except json.JSONDecodeError as e:
+            print("Could not load JSON. Trying to repair.")
+            dict_response, success = repair(response, str(e))
+            if not success:
+                raise Exception("Even the repair failed.")
+        return dict_response
 
     #######################
     # USEFUL METHODS

--- a/edsl/language_models/LanguageModel.py
+++ b/edsl/language_models/LanguageModel.py
@@ -10,7 +10,6 @@ from edsl.exceptions import LanguageModelResponseNotJSONError
 from edsl.language_models.schemas import model_prices
 from edsl.trackers.TrackerAPI import TrackerAPI
 
-# from edsl.utilities import repair_json
 
 from edsl.language_models.repair import repair
 
@@ -38,12 +37,62 @@ class LanguageModel(ABC):
     def execute_model_call(
         self, prompt: str, system_prompt: str = ""
     ) -> dict[str, Any]:
-        """Calls the LLM's API and returns the API response."""
+        """Calls the LLM's API and returns the API response.
+        This is an abstract method that needs to be implemented by the child class, on a
+        model (and API-provider basis).
+
+        For example, the GPT-4 model (as or right now)
+        requires an API call that looks like this:
+
+            openai.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                top_p=self.top_p,
+                frequency_penalty=self.frequency_penalty,
+                presence_penalty=self.presence_penalty,
+            ).model_dump()
+
+        It will then return JSON that needs to be parsed.
+        This is also model/API specific.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def parse_response(raw_response: dict[str, Any]) -> str:
-        """Parses the API response and returns the response text."""
+        """Parses the API response and returns the response text.
+        What is returned by the API is model-specific and often includes meta-data that we do not need.
+        For example, here is the results from a call to GPT-4:
+
+        {
+            "id": "chatcmpl-8eORaeuVb4po9WQRjKEFY6w7v6cTm",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "index": 0,
+                    "logprobs": None,
+                    "message": {
+                        "content": "Hello! How can I assist you today? If you have any questions or need information on a particular topic, feel free to ask.",
+                        "role": "assistant",
+                        "function_call": None,
+                        "tool_calls": None,
+                    },
+                }
+            ],
+            "created": 1704637774,
+            "model": "gpt-4-1106-preview",
+            "object": "chat.completion",
+            "system_fingerprint": "fp_168383a679",
+            "usage": {"completion_tokens": 27, "prompt_tokens": 13, "total_tokens": 40},
+        }
+
+        To actually tract the response, we need to grab
+            data["choices[0]"]["message"]["content"].
+        """
         raise NotImplementedError
 
     def _update_response_with_tracking(
@@ -57,8 +106,14 @@ class LanguageModel(ABC):
             response["cached_response"] = cached_response
         return response
 
-    def get_raw_response(self, prompt: str, system_prompt: str = "") -> dict[str, Any]:
-        """Calls the LLM's API and returns the API response.
+    def _get_raw_response(self, prompt: str, system_prompt: str = "") -> dict[str, Any]:
+        """This is some middle-ware that handles the caching of responses.
+        If the cache isn't being used, it just returns a 'fresh' call to the LLM,
+        but appends some tracking information to the response (using the _update_response_with_tracking method).
+        But if cache is being used, it first checks the database to see if the response is already there.
+        If it is, it returns the cached response, but again appends some tracking information.
+        If it isn't, it calls the LLM, saves the response to the database, and returns the response with tracking information.
+
         If self.use_cache is True, then attempts to retrieve the response from the database;
         if not in the DB, calls the LLM and writes the response to the DB."""
         start_time = time.time()
@@ -99,7 +154,7 @@ class LanguageModel(ABC):
 
     def get_response(self, prompt: str, system_prompt: str = ""):
         """Get response, parse, and return as string."""
-        raw_response = self.get_raw_response(prompt, system_prompt)
+        raw_response = self._get_raw_response(prompt, system_prompt)
         response = self.parse_response(raw_response)
         try:
             dict_response = json.loads(response)

--- a/edsl/language_models/registry.py
+++ b/edsl/language_models/registry.py
@@ -1,0 +1,25 @@
+import importlib
+
+DEFAULT_MODEL_CLASS = "edsl.language_models.LanguageModelOpenAIFour"
+
+# TODO: Use a meta-class to register models
+model_names_to_classes = {
+    "gpt-3.5-turbo": "edsl.language_models.LanguageModelOpenAIThreeFiveTurbo",
+    "gpt-4": "edsl.language_models.LanguageModelOpenAIFour",
+}
+
+
+def get_model_class(model_name):
+    "Returns the class for a given model name"
+    class_path = model_names_to_classes.get(model_name, DEFAULT_MODEL_CLASS)
+    module_name, class_name = class_path.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    cls = getattr(module, class_name)
+    return cls
+
+
+if __name__ == "__main__":
+    model_class = get_model_class("gpt-4")
+    model = model_class()
+    results = model.execute_model_call("Hello world")
+    print(results)

--- a/edsl/language_models/repair.py
+++ b/edsl/language_models/repair.py
@@ -15,6 +15,7 @@ def repair(bad_json, error_message=""):
         valid_dict = json.loads(results["choices"][0]["message"]["content"])
     except json.JSONDecodeError:
         success = False
+        valid_dict = {}
     return valid_dict, success
 
 

--- a/edsl/language_models/repair.py
+++ b/edsl/language_models/repair.py
@@ -1,0 +1,33 @@
+import json
+
+
+def repair(bad_json, error_message=""):
+    from edsl.language_models import LanguageModelOpenAIFour
+
+    m = LanguageModelOpenAIFour()
+    results = m.execute_model_call(
+        f"""Please repair this bad JSON: {bad_json}."""
+        + (f"Parsing error message: {error_message}" if error_message else ""),
+        system_prompt="You are a helpful agent. Only return the repaired JSON, nothing else.",
+    )
+    success = True
+    try:
+        valid_dict = json.loads(results["choices"][0]["message"]["content"])
+    except json.JSONDecodeError:
+        success = False
+    return valid_dict, success
+
+
+if __name__ == "__main__":
+    bad_json = """
+    {
+      'answer': "The problematic phrase in the excerpt is \'typically\'. This word is vague and can lead to different interpretations. An alternative phrasing that would be less problematic is: 
+      'On average, how long do you cook scrambled eggs?}
+    """
+    try:
+        json.loads(bad_json)
+        print("Loaded")
+    except json.JSONDecodeError as e:
+        error_message = str(e)
+        repaired, success = repair(bad_json, error_message)
+        print(f"Repaired: {repaired}")

--- a/tests/language_models/test_LanguageModel.py
+++ b/tests/language_models/test_LanguageModel.py
@@ -1,0 +1,48 @@
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+
+from edsl.language_models.LanguageModel import LanguageModel
+
+
+class TestLanguageModel(unittest.TestCase):
+    def setUp(self):
+        class TestLanguageModelBad(LanguageModel):
+            pass
+
+        self.bad_class = TestLanguageModelBad
+
+        class TestLanguageModelGood(LanguageModel):
+            use_cache = False
+
+            def execute_model_call(self, prompt, system_prompt):
+                return {"message": """{"answer": "Hello world"}"""}
+
+            def parse_response(self, raw_response):
+                return raw_response["message"]
+
+        self.good_class = TestLanguageModelGood
+
+    def test_abstract_methods_missing(self):
+        with self.assertRaises(TypeError):
+            m = self.bad_class()
+
+    def test_execute_model_call(self):
+        m = self.good_class()
+        response = m._get_raw_response(
+            prompt="Hello world", system_prompt="You are a helpful agent"
+        )
+        print(response)
+        self.assertEqual(response["message"], """{"answer": "Hello world"}""")
+        self.assertEqual(response["cached_response"], False)
+
+    def test_get_response(self):
+        m = self.good_class()
+        response = m.get_response(
+            prompt="Hello world", system_prompt="You are a helpful agent"
+        )
+        self.assertEqual(response, {"answer": "Hello world"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/language_models/test_LanguageModel.py
+++ b/tests/language_models/test_LanguageModel.py
@@ -88,8 +88,10 @@ class TestLanguageModel(unittest.TestCase):
 
         # call again with same prompt - should not write to db again
         m.get_response(prompt="Hello world", system_prompt="You are a helpful agent")
-        num_responses = len(cursor.execute("SELECT * FROM responses").fetchall())
+        new_responses = cursor.execute("SELECT * FROM responses").fetchall()
+        num_responses = len(new_responses)
         self.assertEqual(num_responses, 1)
+        self.assertEqual(new_responses[0], tuple(expected_response.values()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This does a few things: 
- Uses a registry to look up model classes 
- Make the LLM caching logic a bit clearer and breaks up the _get_raw_response into clearer bits 
- Adds more documentation for each of the abstract methods that child classes need to implement 
- Replaces JSON repair functionality with a straight call to GPT4 rather than fiddling w/ strings
- Adds tests/language_model that tests most of the functionality of LanguageModel, including caching