### PR TITLE
Re-factoring of Survey to add greater clarity

### DIFF
--- a/edsl/surveys/descriptors.py
+++ b/edsl/surveys/descriptors.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from typing import Any
+from edsl.questions import Question
+
+
+class BaseDescriptor(ABC):
+    """ABC for something."""
+
+    @abstractmethod
+    def validate(self, value: Any) -> None:
+        """Validates the value. If it is invalid, raises an exception. If it is valid, does nothing."""
+        pass
+
+    def __get__(self, instance, owner):
+        """"""
+        return instance.__dict__[self.name]
+
+    def __set__(self, instance, value: Any) -> None:
+        self.validate(value, instance)
+        instance.__dict__[self.name] = value
+
+    def __set_name__(self, owner, name: str) -> None:
+        self.name = "_" + name
+
+
+class QuestionsDescriptor(BaseDescriptor):
+    """Descriptor for questions."""
+
+    def __get__(self, instance, owner):
+        """"""
+        return instance.__dict__[self.name]
+
+    def validate(self, value: Any, instance) -> None:
+        if not isinstance(value, list):
+            raise TypeError("Questions must be a list.")
+        if not all(isinstance(question, Question) for question in value):
+            raise TypeError("Questions must be a list of Question objects.")
+        question_names = [question.question_name for question in value]
+        if len(question_names) != len(set(question_names)):
+            raise ValueError("Question names must be unique.")
+
+    def __set__(self, instance, value: Any) -> None:
+        self.validate(value, instance)
+        instance.__dict__[self.name] = []
+        for question in value:
+            instance.add_question(question)
+
+    def __set_name__(self, owner, name: str) -> None:
+        self.name = "_" + name


### PR DESCRIPTION
Before starting on memory, I wanted to just clean up the Survey class a bit. 
Main changes: 

* De-facto deprecated passing question_names to Survey (as each question should have a name); currently just a warning.  Eventually, we can remove all altogether.
* Refactored lookups of questions by name to be a property rather than a new mutable we have to keep track of. Longer term, we might just implement the dictionary methods so you can use survey 'like' a dictionary where keys are the question names. 
* Re-factored the add_question code to be clearer about how it works, esp. rule generation
* Created a SurveyMetaData class for storing stuff like the survey name, version, when created etc. 
* Made the rule-adding more explicit
* Use a descriptor pattern for setting the questions so uniqueness checks are enforced there
* Moved the "code" stuff to a SurveyExport mixin to make the main code clearer