### PR TITLE
Re-factor survey-taking code in preparation for adding Memory

### DIFF
--- a/edsl/jobs/Interview.py
+++ b/edsl/jobs/Interview.py
@@ -1,11 +1,32 @@
 from __future__ import annotations
 from tenacity import retry, wait_exponential, stop_after_attempt
-from typing import Any, Type
+from typing import Any, Type, Union
 from edsl.agents import Agent
 from edsl.language_models import LanguageModel
 from edsl.questions import Question
 from edsl.scenarios import Scenario
 from edsl.surveys import Survey
+
+from collections import UserDict
+
+
+class Answers(UserDict):
+    "Helper class to hold the answers to a survey"
+
+    def add_answer(self, response, question) -> None:
+        "Adds a response to the answers dictionary"
+        answer = response.get("answer")
+        comment = response.pop("comment", None)
+        # record the answer
+        self[question.question_name] = answer
+        if comment:
+            self[question.question_name + "_comment"] = comment
+
+    def replace_missing_answers_with_none(self, survey) -> None:
+        "Replaces missing answers with None. Answers can be missing if the agent skips a question."
+        for question_name in survey.question_names:
+            if question_name not in self:
+                self[question_name] = None
 
 
 class Interview:
@@ -31,11 +52,11 @@ class Interview:
         self.model = model
         self.debug = debug
         self.verbose = verbose
-        self.answers: dict[str, str] = {}
+        self.answers: dict[str, str] = Answers()
 
     def conduct_interview(
         self, debug: bool = False, replace_missing: bool = True, threaded: bool = False
-    ) -> dict[str, Any]:
+    ) -> "Answers":
         """
         Conducts the interview using a generator from the Survey object to traverse through the survey. Sends answers to the Survey, which then sends back the next Question.
 
@@ -46,34 +67,25 @@ class Interview:
         Returns:
         - `answers`: a dictionary of answers to the survey questions, with keys as question names and values as answers. If the agent also produced a comment, the comment is stored in a key with the question name plus "_comment" appended to it.
         """
-        # get the first question
         path_through_survey = self.survey.gen_path_through_survey()
         question = next(path_through_survey)
-        survey_inprogress = True
 
-        while survey_inprogress:
-            # get agent's response to the question
-            if threaded:
-                raise NotImplementedError
-            else:
-                response = self.get_response(question, debug=debug)
-            # resolve
-            answer = response.get("answer")
-            comment = response.pop("comment", None)
-            # record the answer
-            self.answers[question.question_name] = answer
-            if comment:
-                self.answers[question.question_name + "_comment"] = comment
-            # send the answer to the survey, to get the next question
+        def get_next_question(answers) -> Union["Question", None]:
+            """Gets the next question from the survey by sending the current answers.
+            If the survey is finished, the generator returns at StopIteration, in which case
+            this returns None, which will end the while-loop."""
             try:
-                question = path_through_survey.send({question.question_name: answer})
+                return path_through_survey.send(answers)
             except StopIteration:
-                survey_inprogress = False
+                return None
+
+        while question:
+            response = self.get_response(question, debug=debug)
+            self.answers.add_answer(response, question)
+            question = get_next_question(self.answers)
 
         if replace_missing:
-            for question_name in self.survey.question_names:
-                if question_name not in self.answers:
-                    self.answers[question_name] = None
+            self.answers.replace_missing_answers_with_none(self.survey)
 
         return self.answers
 

--- a/edsl/surveys/base.py
+++ b/edsl/surveys/base.py
@@ -14,3 +14,6 @@ class EndOfSurvey:
 
     def __str__(self):
         return "EndOfSurvey"
+
+    def __bool__(self):
+        return False

--- a/tests/agents/test_Invigilators.py
+++ b/tests/agents/test_Invigilators.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import Mock
+from edsl.agents.Invigilator import InvigilatorDebug, InvigilatorHuman
+
+
+class TestInvigilatorDebug(unittest.TestCase):
+    def test_answer_question(self):
+        agent = Mock()
+        question = Mock()
+        question.simulate_answer.return_value = "Mocked Answer"
+        scenario = Mock()
+        model = Mock()
+
+        invigilator = InvigilatorDebug(agent, question, scenario, model)
+        self.assertEqual(invigilator.answer_question(), "Mocked Answer")
+
+
+class TestInvigilatorHuman(unittest.TestCase):
+    def test_answer_question(self):
+        agent = Mock()
+        agent.answer_question_directly.return_value = "Human Answer"
+        question = Mock()
+        question.validate_response.side_effect = lambda x: x  # Just return the input
+        scenario = Mock()
+        model = Mock()
+
+        invigilator = InvigilatorHuman(agent, question, scenario, model)
+        response = invigilator.answer_question()
+        self.assertEqual(response["answer"], "Human Answer")
+        self.assertEqual(response["model"], "human")
+        self.assertEqual(response["scenario"], scenario)
+
+
+# Similarly, write test cases for InvigilatorFunctional and InvigilatorAI
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/surveys/test_Survey.py
+++ b/tests/surveys/test_Survey.py
@@ -26,7 +26,7 @@ class TestSurvey(unittest.TestCase):
 
     def test_default_sequence(self):
         s = self.gen_survey()
-        self.assertEqual(s._questions[0], s.next_question())
+        self.assertEqual(s._questions[0], s.first_question())
         self.assertEqual(s._questions[1], s.next_question("like_school", {}))
         self.assertEqual(s._questions[2], s.next_question("favorite_subject", {}))
 


### PR DESCRIPTION
This PR is made in preparation of adding memory capabilities to survey-taking

- Re-factors the gen_path_through_survey code so logic is clearer
- Refactors generator to just work with question objects rather than question_names, which I think is clearer
- Adds a helper 'Answers' class to Interview.py, pushing some of logic there for clarity
- Hides some of the generator weirdness from the user with some helper functions e.g., "get_next_question" 
- Eliminates the while True / break pattern, which I think is ugly