### PR TITLE
Async surveys - Part I: DAG preparation

### DIFF
--- a/edsl/jobs/Answers.py
+++ b/edsl/jobs/Answers.py
@@ -1,0 +1,20 @@
+from collections import UserDict
+
+
+class Answers(UserDict):
+    "Helper class to hold the answers to a survey"
+
+    def add_answer(self, response, question) -> None:
+        "Adds a response to the answers dictionary"
+        answer = response.get("answer")
+        comment = response.pop("comment", None)
+        # record the answer
+        self[question.question_name] = answer
+        if comment:
+            self[question.question_name + "_comment"] = comment
+
+    def replace_missing_answers_with_none(self, survey) -> None:
+        "Replaces missing answers with None. Answers can be missing if the agent skips a question."
+        for question_name in survey.question_names:
+            if question_name not in self:
+                self[question_name] = None

--- a/edsl/jobs/InterviewAsync.py
+++ b/edsl/jobs/InterviewAsync.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+import asyncio
+
+# from tenacity import retry, wait_exponential, stop_after_attempt
+from typing import Any, Type, Union
+from edsl.agents import Agent
+from edsl.language_models import LanguageModel
+from edsl.questions import Question
+from edsl.scenarios import Scenario
+from edsl.surveys import Survey
+from edsl.utilities.decorators import sync_wrapper
+
+from edsl.jobs.Answers import Answers
+
+## How does the with_survey_async version work?
+## 1. The tasks are all the questions
+## 2. Get the DAG for the survey
+
+
+def task_wrapper(name, delay, dependencies=[]):
+    async def run_task():
+        for dependency in dependencies:
+            await dependency
+        return await task(name, delay)
+
+    # Using create_task instead of ensure_future
+    return asyncio.create_task(run_task())
+
+
+class Interview:
+    """
+    A class that has an Agent answer Survey Questions with a particular Scenario and using a LanguageModel.
+    - `Agent.answer_question(question, scenario, model)` is called for each question in the Survey to get an answer to a question.
+    - `Survey.gen_path_through_survey()` is called to get a generator that traverses through the Survey.
+    - `conduct_interview()` is called to conduct the interview, and returns the answers and comments to the questions in the Survey.
+    """
+
+    def __init__(
+        self,
+        agent: Agent,
+        survey: Survey,
+        scenario: Scenario,
+        model: Type[LanguageModel],
+        verbose: bool = False,
+        debug: bool = False,
+    ):
+        self.agent = agent
+        self.survey = survey
+        self.scenario = scenario
+        self.model = model
+        self.debug = debug
+        self.verbose = verbose
+        self.answers: dict[str, str] = Answers()
+
+    async def async_conduct_interview(
+        self, debug: bool = False, replace_missing: bool = True, threaded: bool = False
+    ) -> "Answers":
+        """ """
+        to_index = {
+            name: index for index, name in enumerate(self.survey.question_names)
+        }
+        # breakpoint()
+
+        async def task(question):
+            response = await self.async_get_response(question, debug=debug)
+            self.answers.add_answer(response, question)
+            return response
+
+        def task_wrapper(question, dependencies=[]):
+            async def run_task():
+                for dependency in dependencies:
+                    await dependency
+                return await task(question)
+
+            return asyncio.create_task(run_task())
+
+        dag = self.survey.dag(textify=True)
+        # breakpoint()
+        tasks = []
+        for question in self.survey.questions:
+            dependencies = [
+                tasks[to_index[question_name]]
+                for question_name in dag.get(question.question_name, [])
+            ]
+            tasks.append(task_wrapper(question, dependencies=dependencies))
+
+        # async def run_all_tasks(tasks):
+        await asyncio.gather(*tasks)
+        # results = asyncio.run(run_all_tasks())
+
+        if replace_missing:
+            self.answers.replace_missing_answers_with_none(self.survey)
+
+        return self.answers
+
+    conduct_interview = sync_wrapper(async_conduct_interview)
+
+    async def async_get_response(
+        self, question: Question, debug: bool = False
+    ) -> dict[str, Any]:
+        """Gets the agent's response to a question with exponential backoff.
+
+        This calls the agent's `answer_question` method, which returns a response dictionary.
+        """
+        response = await self.agent.async_answer_question(
+            question=question,
+            scenario=self.scenario,
+            model=self.model,
+            debug=debug,
+            memory_plan=self.survey.memory_plan,
+            current_answers=self.answers,
+        )
+        return response
+
+    get_response = sync_wrapper(async_get_response)
+
+    #######################
+    # Dunder methods
+    #######################
+    def __repr__(self) -> str:
+        """Returns a string representation of the Interview instance."""
+        return f"Interview(agent = {self.agent}, survey = {self.survey}, scenario = {self.scenario}, model = {self.model})"
+
+
+# def main():
+if __name__ == "__main__":
+    from edsl.language_models import LanguageModelOpenAIThreeFiveTurbo
+    from edsl.agents import Agent
+    from edsl.surveys import Survey
+    from edsl.scenarios import Scenario
+    from edsl.questions import QuestionMultipleChoice
+
+    # from edsl.jobs.Interview import Interview
+
+    #  a survey with skip logic
+    q0 = QuestionMultipleChoice(
+        question_text="Do you like school?",
+        question_options=["yes", "no"],
+        question_name="q0",
+    )
+    q1 = QuestionMultipleChoice(
+        question_text="Why not?",
+        question_options=["killer bees in cafeteria", "other"],
+        question_name="q1",
+    )
+    q2 = QuestionMultipleChoice(
+        question_text="Why?",
+        question_options=["**lack*** of killer bees in cafeteria", "other"],
+        question_name="q2",
+    )
+    s = Survey(questions=[q0, q1, q2])
+    s = s.add_rule(q0, "q0 == 'yes'", q2)
+
+    # create an interview
+    a = Agent(traits=None)
+    scenario = Scenario()
+    m = LanguageModelOpenAIThreeFiveTurbo(use_cache=True)
+    I = Interview(agent=a, survey=s, scenario=scenario, model=m)
+
+    # conduct five interviews
+    for _ in range(5):
+        I.conduct_interview(debug=True)
+
+    # replace missing answers
+    I
+    repr(I)
+    eval(repr(I))

--- a/edsl/surveys/MemoryPlan.py
+++ b/edsl/surveys/MemoryPlan.py
@@ -90,3 +90,25 @@ class MemoryPlan(UserDict):
         memory_plan.question_texts = data["survey_question_texts"]
         # memory_plan.data = data
         return memory_plan
+
+    def _indexify(self, d):
+        new_d = {}
+        for k, v in d.items():
+            key = self.survey_question_names.index(k)
+            new_v = set({self.survey_question_names.index(q) for q in v})
+            new_d[key] = new_v
+        return new_d
+
+    @property
+    def dag(self):
+        d = {}
+        "Returns a directed acyclic graph of the memory plan"
+        for focal_question, memory in self.items():
+            for prior_question in memory:
+                if focal_question not in d:
+                    d[focal_question] = set({prior_question})
+                else:
+                    d[focal_question].add(prior_question)
+        # focal_index = self.survey_question_names.index(focal_question)
+        # prior_index = self.survey_question_names.index(prior_question)
+        return self._indexify(d)

--- a/edsl/surveys/Rule.py
+++ b/edsl/surveys/Rule.py
@@ -2,7 +2,7 @@ import ast
 from collections import namedtuple
 from rich import print
 from simpleeval import EvalWithCompoundTypes
-from typing import Any, Union
+from typing import Any, Union, List
 from edsl.exceptions import (
     SurveyRuleCannotEvaluateError,
     SurveyRuleCollectionHasNoRulesAtNodeError,
@@ -171,114 +171,6 @@ class Rule:
         except Exception as e:
             print(f"Exception in evaluation: {e}")
             raise SurveyRuleCannotEvaluateError
-
-
-NextQuestion = namedtuple(
-    "NextQuestion", "next_q, num_rules_found, expressions_evaluating_to_true, priority"
-)
-
-
-class RuleCollection:
-    "A collection of rules for a particular survey"
-
-    def __init__(self, rules=None, verbose=False):
-        if rules is None:
-            self.rules = []
-        else:
-            self.rules = rules
-        self.verbose = verbose
-
-    def __len__(self):
-        return len(self.rules)
-
-    def __getitem__(self, index):
-        return self.rules[index]
-
-    def __repr__(self):
-        return f"RuleCollection(rules = {self.rules})"
-
-    def to_dict(self):
-        return [rule.to_dict() for rule in self.rules]
-
-    @classmethod
-    def from_dict(self, rule_collection_dict):
-        return RuleCollection(
-            rules=[Rule.from_dict(rule_dict) for rule_dict in rule_collection_dict]
-        )
-
-    def add_rule(self, rule: Rule):
-        """Adds a rule to a survey. If it's not, return human-readable complaints"""
-        self.rules.append(rule)
-
-    def show_rules(self) -> None:
-        if self.verbose:
-            keys = ["current_q", "expression", "next_q", "priority"]
-            rule_list = []
-            for rule in sorted(self.rules, key=lambda r: r.current_q):
-                rule_list.append({k: getattr(rule, k) for k in keys})
-
-            print_table_with_rich(rule_list)
-
-    def which_rules(self, q_now) -> list:
-        """Which rules apply at the current node?
-        More than one rule can apply. E.g., suppose we are at node 1.
-        We could have three rules:
-        1. "q1 == 'a' ==> 3
-        2. "q1 == 'b' ==> 4
-        3. "q1 == 'c' ==> 5
-        """
-        applicable_rules = [rule for rule in self.rules if rule.current_q == q_now]
-        return applicable_rules
-
-    def next_question(self, q_now, answers) -> int:
-        "Find the next question by index, given the rule collection"
-        # what rules apply at the current node?
-        applicable_rules = self.which_rules(q_now)
-        # Every node should have a rule - if it doesn't, there's a problem
-        if not applicable_rules:
-            raise SurveyRuleCollectionHasNoRulesAtNodeError
-
-        # tracking
-        expressions_evaluating_to_true = 0
-        next_q = None
-        highest_priority = -2  # start with -2 to 'pick up' the default rule added
-        num_rules_found = 0
-
-        for rule in applicable_rules:
-            num_rules_found += 1
-            try:
-                if rule.evaluate(answers):  # evaluates to True
-                    expressions_evaluating_to_true += 1
-                    if rule.priority > highest_priority:  # higher priority
-                        # we have a new champ!
-                        next_q, highest_priority = rule.next_q, rule.priority
-            except SurveyRuleCannotEvaluateError:
-                pass
-
-        return NextQuestion(
-            next_q, num_rules_found, expressions_evaluating_to_true, highest_priority
-        )
-
-    def all_nodes_reachable(self) -> bool:
-        """Are all nodes reachable, given rule set?
-        To do the tree traversal, you'd have to instantiate answers to check.
-        What would you do for continuous measures? Probably fork at above/below threshold?
-
-        You could use the rules to help you draw the tree, no?
-        Like you start linear
-        Then take a rule, given it's conditions - figure out what options you need to track
-        to build the tree e.g., if it mentions q1.answer, you need to add leafs at that node
-        """
-        raise NotImplementedError
-
-    def no_cycles(self, rules: list[Rule]) -> bool:
-        """Ensures there are not cycles in the rule set, which would create an infinite loop
-        Probably also put a check in the Exam class to make sure they
-        don't see the same question more than once - though
-        that could be OK if their prompt text has changed.
-        Python 3.10 has a topological sort, so
-        """
-        raise NotImplemented
 
 
 if __name__ == "__main__":

--- a/edsl/surveys/RuleCollection.py
+++ b/edsl/surveys/RuleCollection.py
@@ -1,0 +1,121 @@
+from typing import List
+from edsl.exceptions import (
+    SurveyRuleCannotEvaluateError,
+    SurveyRuleCollectionHasNoRulesAtNodeError,
+)
+from edsl.utilities.interface import print_table_with_rich
+from edsl.surveys.Rule import Rule
+
+from collections import namedtuple
+
+NextQuestion = namedtuple(
+    "NextQuestion", "next_q, num_rules_found, expressions_evaluating_to_true, priority"
+)
+
+
+class RuleCollection:
+    "A collection of rules for a particular survey"
+
+    def __init__(self, rules=None, verbose=False):
+        if rules is None:
+            self.rules = []
+        else:
+            self.rules = rules
+        self.verbose = verbose
+
+    def __len__(self):
+        return len(self.rules)
+
+    def __getitem__(self, index):
+        return self.rules[index]
+
+    def __repr__(self):
+        return f"RuleCollection(rules = {self.rules})"
+
+    def to_dict(self):
+        return [rule.to_dict() for rule in self.rules]
+
+    @classmethod
+    def from_dict(self, rule_collection_dict):
+        return RuleCollection(
+            rules=[Rule.from_dict(rule_dict) for rule_dict in rule_collection_dict]
+        )
+
+    def add_rule(self, rule: Rule):
+        """Adds a rule to a survey. If it's not, return human-readable complaints"""
+        self.rules.append(rule)
+
+    def show_rules(self) -> None:
+        if self.verbose:
+            keys = ["current_q", "expression", "next_q", "priority"]
+            rule_list = []
+            for rule in sorted(self.rules, key=lambda r: r.current_q):
+                rule_list.append({k: getattr(rule, k) for k in keys})
+
+            print_table_with_rich(rule_list)
+
+    def which_rules(self, q_now) -> list:
+        """Which rules apply at the current node?
+        More than one rule can apply. E.g., suppose we are at node 1.
+        We could have three rules:
+        1. "q1 == 'a' ==> 3
+        2. "q1 == 'b' ==> 4
+        3. "q1 == 'c' ==> 5
+        """
+        applicable_rules = [rule for rule in self.rules if rule.current_q == q_now]
+        return applicable_rules
+
+    def next_question(self, q_now, answers) -> int:
+        "Find the next question by index, given the rule collection"
+        # what rules apply at the current node?
+        applicable_rules = self.which_rules(q_now)
+        # Every node should have a rule - if it doesn't, there's a problem
+        if not applicable_rules:
+            raise SurveyRuleCollectionHasNoRulesAtNodeError
+
+        # tracking
+        expressions_evaluating_to_true = 0
+        next_q = None
+        highest_priority = -2  # start with -2 to 'pick up' the default rule added
+        num_rules_found = 0
+
+        for rule in applicable_rules:
+            num_rules_found += 1
+            try:
+                if rule.evaluate(answers):  # evaluates to True
+                    expressions_evaluating_to_true += 1
+                    if rule.priority > highest_priority:  # higher priority
+                        # we have a new champ!
+                        next_q, highest_priority = rule.next_q, rule.priority
+            except SurveyRuleCannotEvaluateError:
+                pass
+
+        return NextQuestion(
+            next_q, num_rules_found, expressions_evaluating_to_true, highest_priority
+        )
+
+    @property
+    def non_default_rules(self) -> List[Rule]:
+        """Returns all rules that are not the default rule"""
+        return [rule for rule in self.rules if rule.priority > -1]
+
+    def all_nodes_reachable(self) -> bool:
+        """Are all nodes reachable, given rule set?
+        To do the tree traversal, you'd have to instantiate answers to check.
+        What would you do for continuous measures? Probably fork at above/below threshold?
+
+        You could use the rules to help you draw the tree, no?
+        Like you start linear
+        Then take a rule, given it's conditions - figure out what options you need to track
+        to build the tree e.g., if it mentions q1.answer, you need to add leafs at that node
+        """
+        raise NotImplementedError
+
+    def no_cycles(self, rules: list[Rule]) -> bool:
+        """Ensures there are not cycles in the rule set, which would create an infinite loop
+        Probably also put a check in the Exam class to make sure they
+        don't see the same question more than once - though
+        that could be OK if their prompt text has changed.
+        Python 3.10 has a topological sort, so
+        """
+        raise NotImplemented

--- a/edsl/surveys/Survey.py
+++ b/edsl/surveys/Survey.py
@@ -51,7 +51,9 @@ class Survey(SurveyExportMixin, Base):
         version: str = None,
     ):
         """Creates a new survey."""
-        self.rule_collection = RuleCollection()
+        self.rule_collection = RuleCollection(
+            num_questions=len(questions) if questions else None
+        )
         self.meta_data = SurveyMetaData(
             name=name, description=description, version=version
         )
@@ -318,6 +320,16 @@ class Survey(SurveyExportMixin, Base):
             # add them to the temp list
             temp.extend(matches)
         return temp
+
+    def dag(self):
+        memory_dag = self.memory_plan.dag
+        rule_dag = self.rule_collection.dag
+        # return {"memory_dag": memory_dag, "rule_dag": rule_dag}
+        d = {}
+        combined_keys = set(memory_dag.keys()).union(set(rule_dag.keys()))
+        for key in combined_keys:
+            d[key] = memory_dag.get(key, set({})).union(rule_dag.get(key, set({})))
+        return d
 
     ###################
     # DUNDER METHODS

--- a/edsl/surveys/Survey.py
+++ b/edsl/surveys/Survey.py
@@ -321,7 +321,15 @@ class Survey(SurveyExportMixin, Base):
             temp.extend(matches)
         return temp
 
-    def dag(self):
+    def textify(self, d):
+        new_d = dict({})
+        for key, value in d.items():
+            new_key = self.questions[key].question_name
+            new_value = set({self.questions[index].question_name for index in value})
+            new_d[new_key] = new_value
+        return new_d
+
+    def dag(self, textify=False):
         memory_dag = self.memory_plan.dag
         rule_dag = self.rule_collection.dag
         # return {"memory_dag": memory_dag, "rule_dag": rule_dag}
@@ -329,7 +337,10 @@ class Survey(SurveyExportMixin, Base):
         combined_keys = set(memory_dag.keys()).union(set(rule_dag.keys()))
         for key in combined_keys:
             d[key] = memory_dag.get(key, set({})).union(rule_dag.get(key, set({})))
-        return d
+        if textify:
+            return self.textify(d)
+        else:
+            return d
 
     ###################
     # DUNDER METHODS

--- a/edsl/surveys/Survey.py
+++ b/edsl/surveys/Survey.py
@@ -7,7 +7,8 @@ from typing import Any, Generator, Optional, Union, List
 from edsl.exceptions import SurveyCreationError, SurveyHasNoRulesError
 from edsl.questions.Question import Question
 from edsl.surveys.base import RulePriority, EndOfSurvey
-from edsl.surveys.Rule import Rule, RuleCollection
+from edsl.surveys.Rule import Rule
+from edsl.surveys.RuleCollection import RuleCollection
 
 from edsl.Base import Base
 from edsl.surveys.SurveyExportMixin import SurveyExportMixin

--- a/edsl/surveys/__init__.py
+++ b/edsl/surveys/__init__.py
@@ -1,2 +1,3 @@
 from edsl.surveys.Survey import Survey
-from edsl.surveys.Rule import Rule, RuleCollection
+from edsl.surveys.Rule import Rule
+from edsl.surveys.RuleCollection import RuleCollection

--- a/tests/surveys/test_RuleCollection.py
+++ b/tests/surveys/test_RuleCollection.py
@@ -31,6 +31,23 @@ class TestRuleCollection(unittest.TestCase):
         self.assertEqual(len(rules_that_apply), 1)
         self.assertEqual(rules_that_apply[0].priority, 1)
 
+    def test_dag(self):
+        rc = RuleCollection()
+
+        rule = Rule(
+            current_q=0,
+            expression="q1 == 'yes'",
+            next_q=1,
+            question_name_to_index={"q1": 0},
+            priority=1,
+        )
+
+        rc.add_rule(rule)
+        # print(rc.non_default_rules)
+
+        print(rc.dag)
+        # breakpoint()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/surveys/test_RuleCollection.py
+++ b/tests/surveys/test_RuleCollection.py
@@ -1,6 +1,7 @@
 import unittest
 from edsl.exceptions import SurveyRuleCollectionHasNoRulesAtNodeError
-from edsl.surveys.Rule import Rule, RuleCollection
+from edsl.surveys.Rule import Rule
+from edsl.surveys.RuleCollection import RuleCollection
 
 
 class TestRuleCollection(unittest.TestCase):

--- a/tests/surveys/test_Survey.py
+++ b/tests/surveys/test_Survey.py
@@ -70,6 +70,27 @@ class TestSurvey(unittest.TestCase):
             },
         )
 
+    def test_dag(self):
+        survey = self.gen_survey()
+        survey.add_rule(
+            survey._questions[0], "like_school == 'no'", survey._questions[2]
+        )
+        survey.add_rule(
+            survey._questions[1], "favorite_subject == 'math'", survey._questions[2]
+        )
+        survey.add_rule(
+            survey._questions[1], "favorite_subject == 'science'", survey._questions[2]
+        )
+        survey.add_rule(
+            survey._questions[1], "favorite_subject == 'english'", survey._questions[2]
+        )
+        survey.add_rule(
+            survey._questions[1], "favorite_subject == 'history'", survey._questions[2]
+        )
+        survey.add_targeted_memory("favorite_subject", "like_school")
+        # breakpoint()
+        self.assertEqual(survey.dag(), {1: {0}, 2: {0, 1}})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Preparing DAGs
This commit creates within-survey DAGs showing the dependencies among questions, based either on rules or memories. It adds a "survey.dag" method to get that dag, which has keys and values corresponding to question indices. 

# Next step
Instead of the path_through_the_survey generator, we will have an asyncio based system with callbacks, where tasks (questions) that are waiting on another question will pause execution.  