### PR TITLE
Making async Interview the default

### DIFF
--- a/edsl/jobs/Jobs.py
+++ b/edsl/jobs/Jobs.py
@@ -10,7 +10,7 @@ from edsl.results import Results
 from edsl.scenarios import Scenario
 from edsl.surveys import Survey
 from edsl.jobs.base import JobsRunnersRegistry, JobsRunnerDescriptor
-from edsl.jobs.Interview import Interview
+from edsl.jobs.InterviewAsync import Interview
 from edsl.api import JobRunnerAPI, ResultsAPI
 
 

--- a/integration/test_runners.py
+++ b/integration/test_runners.py
@@ -1,0 +1,36 @@
+import random
+import time
+
+from edsl.surveys import Survey
+from edsl.questions import QuestionMultipleChoice
+from edsl.scenarios.ScenarioList import ScenarioList
+from edsl.language_models import LanguageModelOpenAIThreeFiveTurbo
+
+random.seed("agents are cool")
+
+m = LanguageModelOpenAIThreeFiveTurbo(use_cache=False)
+
+flip_results = [
+    {"coin_flip_observed": random.choice(["heads", "tails"])} for _ in range(20)
+]
+flip_scenarios = ScenarioList.gen(flip_results)
+
+q1 = QuestionMultipleChoice(
+    question_text="""You just observed a coin flip that had a value {{coin_flip_observed}}. 
+    What is the result of the coin flip?""",
+    question_options=["heads", "tails"],
+    question_name="q1",
+)
+
+start = time.time()
+results = q1.by(flip_scenarios).by(m).run(method="serial")
+end = time.time()
+serial_time = end - start
+
+start = time.time()
+results = q1.by(flip_scenarios).by(m).run(method="asyncio")
+end = time.time()
+async_time = end - start
+
+print(f"Serial time: {serial_time}")
+print(f"Async time: {async_time}")

--- a/tests/jobs/test_Jobs.py
+++ b/tests/jobs/test_Jobs.py
@@ -1,7 +1,7 @@
 import pytest
 from edsl.agents import Agent
 from edsl.exceptions import AgentCombinationError, JobsRunError
-from edsl.jobs.Interview import Interview
+from edsl.jobs.InterviewAsync import Interview
 from edsl.jobs.Jobs import Jobs, main
 from edsl.questions import QuestionMultipleChoice
 from edsl.scenarios import Scenario


### PR DESCRIPTION
This PR makes:
- [ ]  async method of conducting surveys the default (replacing the old path through the generator approach)
- [ ] Makes the asyncio the default runner for a survey
- [ ] Adds an integration test comparing the asyncio and serial methods