### PR TITLE
Re-factor prompt-related logic out of Question class

### DIFF
--- a/edsl/agents/Invigilator.py
+++ b/edsl/agents/Invigilator.py
@@ -61,11 +61,6 @@ class InvigilatorFunctional(InvigilatorBase):
         return func(scenario=self.scenario, agent_traits=self.agent.traits)
 
 
-################################
-### This is the one that matters
-################################
-
-
 class InvigilatorAI(InvigilatorBase):
     def construct_system_prompt(self) -> Prompt:
         """Constructs the system prompt for the LLM call."""

--- a/edsl/agents/Invigilator.py
+++ b/edsl/agents/Invigilator.py
@@ -1,13 +1,61 @@
 from abc import ABC, abstractmethod
 import asyncio
 import json
-from typing import Coroutine, Dict
+from typing import Coroutine, Dict, Any
 from edsl.exceptions import AgentRespondedWithBadJSONError
 from edsl.prompts.Prompt import Prompt
+
+from jinja2 import Template, Environment, meta
 
 from edsl.utilities.decorators import sync_wrapper, jupyter_nb_handler
 
 from collections import UserDict
+
+from edsl.prompts.Prompt import get_classes
+from edsl.exceptions import QuestionScenarioRenderError
+
+
+# ############################
+# # LLM methods
+# ############################
+def render(text: str, replacements: dict[str, Any]) -> str:
+    """
+    Replaces the variables in the question text with the values from the scenario.
+    - We allow nesting, and hence we may need to do this many times. There is a nesting limit of 100.
+    """
+    t = text
+    MAX_NESTING = 100
+    counter = 0
+    while True:
+        counter += 1
+        new_t = Template(t).render(replacements)
+        if new_t == t:
+            break
+        t = new_t
+        if counter > MAX_NESTING:
+            raise QuestionScenarioRenderError(
+                "Too much nesting - you created an infnite loop here, pal"
+            )
+
+    return new_t
+
+
+# def get_prompt(self, scenario=None) -> Prompt:
+#     """Shows which prompt should be used with the LLM for this question.
+#     It extracts the question attributes from the instantiated question data model.
+#     """
+#     scenario = scenario or {}
+#     template = Template(self.instructions)
+#     template_with_attributes = template.render(self.data)
+# env = Environment()
+# ast = env.parse(template_with_attributes)
+# undeclared_variables = meta.find_undeclared_variables(ast)
+# if any([v not in scenario for v in undeclared_variables]):
+#     raise QuestionScenarioRenderError(
+#         f"Scenario is missing variables: {undeclared_variables}"
+#     )
+#     prompt = self.scenario_render(template_with_attributes, scenario)
+#     return Prompt(prompt)
 
 
 class InvigilatorBase(ABC):
@@ -60,6 +108,11 @@ class InvigilatorFunctional(InvigilatorBase):
         return func(scenario=self.scenario, agent_traits=self.agent.traits)
 
 
+################################
+### This is the one that matters
+############################
+
+
 class InvigilatorAI(InvigilatorBase):
     def construct_system_prompt(self) -> str:
         """Constructs the system prompt for the LLM call."""
@@ -84,10 +137,34 @@ class InvigilatorAI(InvigilatorBase):
 
     get_response = sync_wrapper(async_get_response)
 
+    def get_question_instructions(self):
+        """Gets the instructions for the question."""
+        applicable_prompts = get_classes(
+            component_type="question_instructions",
+            question_type=self.question.question_type,
+        )
+        ## Get the question instructions
+        template = applicable_prompts[0]().text
+        ## Populate with the question data
+        template_with_attributes = Template(template).render(self.question.data)
+
+        env = Environment()
+        ast = env.parse(template_with_attributes)
+        undeclared_variables = meta.find_undeclared_variables(ast)
+        if any([v not in self.scenario for v in undeclared_variables]):
+            raise QuestionScenarioRenderError(
+                f"Scenario is missing variables: {undeclared_variables}"
+            )
+        ## File in the scenario data
+        txt = render(template_with_attributes, self.scenario)
+        return txt
+
     def get_prompts(self) -> Dict[str, Prompt]:
         """Gets the prompts for the LLM call."""
         system_prompt = Prompt(self.construct_system_prompt())
-        user_prompt = Prompt(self.question.get_prompt(self.scenario))
+        user_prompt = Prompt(self.get_question_instructions())
+        # breakpoint()
+        # user_prompt = Prompt(self.question.get_prompt(self.scenario))
         if self.memory_plan is not None:
             user_prompt += self.create_memory_prompt(self.question.question_name)
         return {"user_prompt": user_prompt, "system_prompt": system_prompt}

--- a/edsl/agents/Invigilator.py
+++ b/edsl/agents/Invigilator.py
@@ -23,39 +23,36 @@ def render(text: str, replacements: dict[str, Any]) -> str:
     Replaces the variables in the question text with the values from the scenario.
     - We allow nesting, and hence we may need to do this many times. There is a nesting limit of 100.
     """
-    t = text
-    MAX_NESTING = 100
-    counter = 0
-    while True:
-        counter += 1
-        new_t = Template(t).render(replacements)
-        if new_t == t:
-            break
-        t = new_t
-        if counter > MAX_NESTING:
-            raise QuestionScenarioRenderError(
-                "Too much nesting - you created an infnite loop here, pal"
-            )
-
-    return new_t
+    for _ in range(MAX_NESTING):
+        t = Template(text).render(replacements)
+        if t == text:
+            return t
+        text = t
+    raise QuestionScenarioRenderError(
+        "Too much nesting - you created an infnite loop here, pal"
+    )
 
 
-# def get_prompt(self, scenario=None) -> Prompt:
-#     """Shows which prompt should be used with the LLM for this question.
-#     It extracts the question attributes from the instantiated question data model.
+# def render(text: str, replacements: dict[str, Any]) -> str:
 #     """
-#     scenario = scenario or {}
-#     template = Template(self.instructions)
-#     template_with_attributes = template.render(self.data)
-# env = Environment()
-# ast = env.parse(template_with_attributes)
-# undeclared_variables = meta.find_undeclared_variables(ast)
-# if any([v not in scenario for v in undeclared_variables]):
-#     raise QuestionScenarioRenderError(
-#         f"Scenario is missing variables: {undeclared_variables}"
-#     )
-#     prompt = self.scenario_render(template_with_attributes, scenario)
-#     return Prompt(prompt)
+#     Replaces the variables in the question text with the values from the scenario.
+#     - We allow nesting, and hence we may need to do this many times. There is a nesting limit of 100.
+#     """
+#     t = text
+#     MAX_NESTING = 100
+#     counter = 0
+#     while True:
+#         counter += 1
+#         new_t = Template(t).render(replacements)
+#         if new_t == t:
+#             break
+#         t = new_t
+#         if counter > MAX_NESTING:
+#             raise QuestionScenarioRenderError(
+#                 "Too much nesting - you created an infnite loop here, pal"
+#             )
+
+#     return new_t
 
 
 class InvigilatorBase(ABC):

--- a/edsl/language_models/LanguageModel.py
+++ b/edsl/language_models/LanguageModel.py
@@ -13,7 +13,12 @@ from edsl.exceptions import LanguageModelResponseNotJSONError
 from edsl.language_models.schemas import model_prices
 from edsl.utilities.decorators import sync_wrapper, jupyter_nb_handler
 
-from edsl.language_models.repair import repair
+# TODO: Need to fix this so it's in the event loop.
+# from edsl.language_models.repair import repair
+
+
+def repair(x):
+    return x
 
 
 class RegisterLanguageModelsMeta(ABCMeta):

--- a/edsl/language_models/LanguageModel.py
+++ b/edsl/language_models/LanguageModel.py
@@ -13,12 +13,7 @@ from edsl.exceptions import LanguageModelResponseNotJSONError
 from edsl.language_models.schemas import model_prices
 from edsl.utilities.decorators import sync_wrapper, jupyter_nb_handler
 
-# TODO: Need to fix this so it's in the event loop.
-# from edsl.language_models.repair import repair
-
-
-def repair(x):
-    return x
+from edsl.language_models.repair import repair
 
 
 class RegisterLanguageModelsMeta(ABCMeta):

--- a/edsl/prompts/Prompt.py
+++ b/edsl/prompts/Prompt.py
@@ -105,6 +105,151 @@ class MultipleChoice(QuestionInstuctionsBase):
     )
 
 
+class CheckBox(QuestionInstuctionsBase):
+    question_type = "checkbox"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are being asked the following question: {{question_text}}
+        The options are 
+        {% for option in question_options %}
+        {{ loop.index0 }}: {{option}}
+        {% endfor %}                       
+        Return a valid JSON formatted like this, selecting only the number of the option: 
+        {"answer": [<put comma-separated list of answer codes here>], "comment": "<put explanation here>"}
+        {% if min_selections != None and max_selections != None and min_selections == max_selections %}
+        You must select exactly {{min_selections}} options.
+        {% elif min_selections != None and max_selections != None %}
+        Minimum number of options that must be selected: {{min_selections}}.      
+        Maximum number of options that must be selected: {{max_selections}}.
+        {% elif min_selections != None %}
+        Minimum number of options that must be selected: {{min_selections}}.      
+        {% elif max_selections != None %}
+        Maximum number of options that must be selected: {{max_selections}}.      
+        {% endif %}        
+        """
+    )
+
+
+class TopK(CheckBox):
+    question_type = "top_k"
+
+
+class LinearScale(QuestionInstuctionsBase):
+    question_type = "linear_scale"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are being asked the following question: {{question_text}}
+        The options are 
+        {% for option in question_options %}
+        {{ loop.index0 }}: {{option}}
+        {% endfor %}                       
+        Return a valid JSON formatted like this, selecting only the code of the option (codes start at 0): 
+        {"answer": <put answer code here>, "comment": "<put explanation here>"}
+        Only 1 option may be selected.
+        """
+    )
+
+
+class ListQuestion(QuestionInstuctionsBase):
+    question_type = "list"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        {{question_text}}
+
+        Your response should be only a valid JSON of the following format:
+        {
+            "answer": <list of comma-separated words or phrases >, 
+            "comment": "<put comment here>"
+        }
+        {% if max_list_items is not none %}
+        The list must not contain more than {{ max_list_items }} items.
+        {% endif %}                                           
+    """
+    )
+
+
+class Numerical(QuestionInstuctionsBase):
+    question_type = "numerical"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are being asked a question that requires a numerical response 
+        in the form of an integer or decimal (e.g., -12, 0, 1, 2, 3.45, ...).
+        Your response must be in the following format:
+        {"answer": "<your numerical answer here>", "comment": "<your explanation here"}
+        You must only include an integer or decimal in the quoted "answer" part of your response. 
+        Here is an example of a valid response:
+        {"answer": "100", "comment": "This is my explanation..."}
+        Here is an example of a response that is invalid because the "answer" includes words:
+        {"answer": "I don't know.", "comment": "This is my explanation..."}
+        If your response is equivalent to zero, your formatted response should look like this:
+        {"answer": "0", "comment": "This is my explanation..."}
+        
+        You are being asked the following question: {{question_text}}
+        {% if min_value is not none %}
+        Minimum answer value: {{min_value}}
+        {% endif %}
+        {% if max_value is not none %}
+        Maximum answer value: {{max_value}}
+        {% endif %}
+        """
+    )
+
+
+class Rank(QuestionInstuctionsBase):
+    question_type = "rank"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are being asked the following question: {{question_text}}
+        The options are 
+        {% for option in question_options %}
+        {{ loop.index0 }}: {{option}}
+        {% endfor %}                       
+        Return a valid JSON formatted like this, selecting the numbers of the options in order of preference, 
+        with the most preferred option first, and the least preferred option last: 
+        {"answer": [<put comma-separated list of answer codes here>], "comment": "<put explanation here>"}
+        Exactly {{num_selections}} options must be selected.
+        """
+    )
+
+
+class Extract(QuestionInstuctionsBase):
+    question_type = "extract"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are given the following input: "{{question_text}}".
+        Create an ANSWER should be formatted like this: "{{ answer_template }}",
+        and it should have the same keys but values extracted from the input.
+        If the value of a key is not present in the input, fill with "null".
+        Return a valid JSON formatted like this: 
+        {"answer": <put your ANSWER here>}
+        ONLY RETURN THE JSON, AND NOTHING ELSE.
+        """
+    )
+
+
+class Budget(QuestionInstuctionsBase):
+    question_type = "budget"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are being asked the following question: {{question_text}}
+        The options are
+        {% for option in question_options %}
+        {{ loop.index0 }}: {{option}}
+        {% endfor %}
+        Return a valid JSON formatted like this, selecting only the number of the option:
+        {"answer": <put answer code here>, "comment": "<put explanation here>"}
+        Only 1 option may be selected.
+        """
+    )
+
+
 # For now
 class LikertFive(MultipleChoice):
     question_type = "likert_five"

--- a/edsl/prompts/Prompt.py
+++ b/edsl/prompts/Prompt.py
@@ -2,6 +2,15 @@ import textwrap
 from abc import ABCMeta, abstractmethod, ABC
 from collections import defaultdict
 
+from typing import Any
+
+from jinja2 import Template, Environment, meta
+
+
+class TemplateRenderError(Exception):
+    "TODO: Move to exceptions file"
+    pass
+
 
 class RegisterPromptsMeta(ABCMeta):
     "Metaclass to register prompts"
@@ -18,8 +27,20 @@ class RegisterPromptsMeta(ABCMeta):
     }
 
     def __init__(cls, name, bases, dct):
+        """
+        >>> class Prompt1(PromptBase):
+        ...     component_type = "test"
+
+        >>> class Prompt1(PromptBase):
+        ...     component_type = "test"
+        Traceback (most recent call last):
+        ...
+        Exception: We already have a Prompt class named Prompt1
+        """
         super(RegisterPromptsMeta, cls).__init__(name, bases, dct)
         if "Base" not in name and name != "Prompt":
+            if name in RegisterPromptsMeta._registry:
+                raise Exception(f"We already have a Prompt class named {name}")
             RegisterPromptsMeta._registry[name] = cls
             attributes = tuple(
                 ["component_type"]
@@ -60,23 +81,142 @@ class PromptBase(ABC, metaclass=RegisterPromptsMeta):
         self.text = text or ""
 
     def __add__(self, other_prompt):
+        """
+        >>> p = Prompt("Hello, {{person}}")
+        >>> p2 = Prompt("How are you?")
+        >>> p + p2
+        Prompt(text='Hello, {{person}}How are you?')
+        >>> p + "How are you?"
+        Prompt(text='Hello, {{person}}How are you?')
+        """
         if isinstance(other_prompt, str):
-            return self.text + other_prompt
+            return self.__class__(self.text + other_prompt)
         else:
             return self.__class__(text=self.text + other_prompt.text)
 
     def __str__(self):
+        """
+        >>> p = Prompt("Hello, {{person}}")
+        >>> str(p)
+        'Hello, {{person}}'
+        """
         return self.text
 
     def __contains__(self, text_to_check):
+        """
+        >>> p = Prompt("Hello, {{person}}")
+        >>> "person" in p
+        True
+        >>> "person2" in p
+        False
+        """
         return text_to_check in self.text
 
     def __repr__(self):
+        """
+        >>> p = Prompt("Hello, {{person}}")
+        >>> p
+        Prompt(text='Hello, {{person}}')
+        """
         return f"Prompt(text='{self.text}')"
+
+    def template_variables(
+        self,
+    ) -> list[str]:
+        """
+        >>> p = Prompt("Hello, {{person}}")
+        >>> p.template_variables()
+        ['person']
+        """
+        return self._template_variables(self.text)
+
+    @staticmethod
+    def _template_variables(template: str) -> list[str]:
+        """ """
+        env = Environment()
+        ast = env.parse(template)
+        return list(meta.find_undeclared_variables(ast))
+
+    @property
+    def is_template(self) -> bool:
+        """
+        >>> p = Prompt("Hello, {{person}}")
+        >>> p.is_template
+        True
+        >>> p = Prompt("Hello, person")
+        >>> p.is_template
+        False
+        """
+        return len(self.template_variables()) > 0
+
+    def render(self, replacements, max_nesting=100) -> None:
+        """Renders the prompt with the replacements
+
+        >>> p = Prompt("Hello, {{person}}")
+        >>> p.render({"person": "John"})
+        >>> p.text
+        'Hello, John'
+        >>> p = Prompt("Hello, {{person}}")
+        >>> p.render({"person": "Mr. {{last_name}}", "last_name": "Horton"})
+        >>> p.text
+        'Hello, Mr. Horton'
+        >>> p.render({"person": "Mr. {{last_name}}", "last_name": "Ho{{letter}}ton"}, max_nesting = 1)
+        >>> p.text
+        'Hello, Mr. Horton'
+        """
+        self.text = self._render(self.text, replacements, max_nesting)
+
+    @staticmethod
+    def _render(text, replacements: dict[str, Any], max_nesting) -> str:
+        """
+        Replaces the variables in the question text with the values from the scenario.
+        We allow nesting, and hence we may need to do this many times. There is a nesting limit of 100.
+        TODO: I'm not sure this is necessary, actually - I think jinja2 does this for us automatically.
+        When I was trying to get it to fail, I couldn't.
+        """
+        for _ in range(max_nesting):
+            t = Template(text).render(replacements)
+            if t == text:
+                return t
+            text = t
+        raise TemplateRenderError(
+            "Too much nesting - you created an infnite loop here, pal"
+        )
+
+    def to_dict(self):
+        """
+        >>> p = Prompt("Hello, {{person}}")
+        >>> p.to_dict()
+        {'text': 'Hello, {{person}}', 'class_name': 'Prompt'}
+        """
+        return {"text": self.text, "class_name": self.__class__.__name__}
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        >>> p = Prompt("Hello, {{person}}")
+        >>> p2 = Prompt.from_dict(p.to_dict())
+        >>> p2
+        Prompt(text='Hello, {{person}}')
+        """
+        class_name = data["class_name"]
+        cls = RegisterPromptsMeta._registry.get(class_name, Prompt)
+        return cls(text=data["text"])
 
 
 class Prompt(PromptBase):
+    component_type = ""
+
+
+class AgentInstruction(PromptBase):
     component_type = "agent_instructions"
+    default_instructions = textwrap.dedent(
+        """\
+    You are playing the role of a human answering survey questions.
+    Do not break character.
+    Your traits are: {{traits}}
+    """
+    )
 
 
 class QuestionInstuctionsBase(PromptBase):
@@ -275,7 +415,24 @@ get_classes = RegisterPromptsMeta.get_classes
 
 
 if __name__ == "__main__":
+    pass
     # q = QuestionInstuctions()
-    d = RegisterPromptsMeta._lookup
-    print(d)
-    get_classes(component_type="question_instructions")
+    # d = RegisterPromptsMeta._lookup
+    # print(d)
+    # get_classes(component_type="question_instructions")
+    # import doctest
+    # doctest.testmod()
+
+    # template = "This is the template {{person}}"
+    # env = Environment()
+    # ast = env.parse(Template(template))
+    # print(meta.find_undeclared_variables(ast))
+
+    # template = "This is the template {{person}}"
+    # env = Environment()
+    # ast = env.parse(template)
+    # print(meta.find_undeclared_variables(ast))
+
+    # Traceback (most recent call last):
+    # ...
+    # TemplateRenderError: Too much nesting - you created an infnite loop here, pal

--- a/edsl/prompts/Prompt.py
+++ b/edsl/prompts/Prompt.py
@@ -78,7 +78,12 @@ class RegisterPromptsMeta(ABCMeta):
 
 class PromptBase(ABC, metaclass=RegisterPromptsMeta):
     def __init__(self, text=None):
-        self.text = text or ""
+        if text is None:
+            if hasattr(self, "default_instructions"):
+                text = self.default_instructions
+            else:
+                text = ""
+        self.text = text
 
     def __add__(self, other_prompt):
         """
@@ -138,13 +143,13 @@ class PromptBase(ABC, metaclass=RegisterPromptsMeta):
         return list(meta.find_undeclared_variables(ast))
 
     @property
-    def is_template(self) -> bool:
+    def has_variables(self) -> bool:
         """
         >>> p = Prompt("Hello, {{person}}")
-        >>> p.is_template
+        >>> p.has_variables
         True
         >>> p = Prompt("Hello, person")
-        >>> p.is_template
+        >>> p.has_variables
         False
         """
         return len(self.template_variables()) > 0
@@ -221,11 +226,6 @@ class AgentInstruction(PromptBase):
 
 class QuestionInstuctionsBase(PromptBase):
     component_type = "question_instructions"
-
-    def __init__(self, text=None):
-        if text is None:
-            text = self.default_instructions
-        super().__init__(text=text)
 
 
 class MultipleChoice(QuestionInstuctionsBase):
@@ -416,6 +416,10 @@ get_classes = RegisterPromptsMeta.get_classes
 
 if __name__ == "__main__":
     pass
+
+    p = AgentInstruction()
+    print(p)
+
     # q = QuestionInstuctions()
     # d = RegisterPromptsMeta._lookup
     # print(d)

--- a/edsl/prompts/Prompt.py
+++ b/edsl/prompts/Prompt.py
@@ -1,15 +1,136 @@
-class Prompt:
-    def __init__(self, text):
-        self.text = text
+import textwrap
+from abc import ABCMeta, abstractmethod, ABC
+from collections import defaultdict
+
+
+class RegisterPromptsMeta(ABCMeta):
+    "Metaclass to register prompts"
+    _registry = defaultdict(list)  # Initialize the registry as a dictionary
+    _lookup = {}
+
+    component_types = {
+        "question_data": [],
+        "question_instructions": ["question_type", "model"],
+        "agent_instructions": [],
+        "agent_data": [],
+        "survey_instructions": [],
+        "survey_data": [],
+    }
+
+    def __init__(cls, name, bases, dct):
+        super(RegisterPromptsMeta, cls).__init__(name, bases, dct)
+        if "Base" not in name and name != "Prompt":
+            RegisterPromptsMeta._registry[name] = cls
+            attributes = tuple(
+                ["component_type"]
+                + RegisterPromptsMeta.component_types.get(cls.component_type, [])
+            )
+            values = tuple([getattr(cls, attr) for attr in attributes])
+            cls._lookup[tuple(zip(attributes, values))] = cls
+
+    @staticmethod
+    def match(new_pairs, existing_pairs):
+        "Checks if the new key matches the existing key"
+        for new_key, new_value in new_pairs.items():
+            if new_key in existing_pairs:
+                if new_value != existing_pairs[new_key]:
+                    return False
+        return True
+
+    @staticmethod
+    def tuple_key_to_dict(pairs):
+        return {key: value for key, value in pairs}
+
+    @classmethod
+    def get_classes(cls, **kwargs):
+        d = cls._lookup
+        values = []
+        for key, value in d.items():
+            if cls.match(kwargs, cls.tuple_key_to_dict(key)):
+                values.append(value)
+        return values
+
+    @classmethod
+    def get_registered_classes(cls):
+        return cls._registry
+
+
+class PromptBase(ABC, metaclass=RegisterPromptsMeta):
+    def __init__(self, text=None):
+        self.text = text or ""
 
     def __add__(self, other_prompt):
         if isinstance(other_prompt, str):
             return self.text + other_prompt
         else:
-            return Prompt(text=self.text + other_prompt.text)
+            return self.__class__(text=self.text + other_prompt.text)
 
     def __str__(self):
         return self.text
 
     def __contains__(self, text_to_check):
         return text_to_check in self.text
+
+    def __repr__(self):
+        return f"Prompt(text='{self.text}')"
+
+
+class Prompt(PromptBase):
+    component_type = "agent_instructions"
+
+
+class QuestionInstuctionsBase(PromptBase):
+    component_type = "question_instructions"
+
+    def __init__(self, text=None):
+        if text is None:
+            text = self.default_instructions
+        super().__init__(text=text)
+
+
+class MultipleChoice(QuestionInstuctionsBase):
+    question_type = "multiple_choice"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are being asked the following question: {{question_text}}
+        The options are
+        {% for option in question_options %}
+        {{ loop.index0 }}: {{option}}
+        {% endfor %}
+        Return a valid JSON formatted like this, selecting only the number of the option:
+        {"answer": <put answer code here>, "comment": "<put explanation here>"}
+        Only 1 option may be selected.
+        """
+    )
+
+
+# For now
+class LikertFive(MultipleChoice):
+    question_type = "likert_five"
+
+
+class YesNo(MultipleChoice):
+    question_type = "yes_no"
+
+
+class FreeText(QuestionInstuctionsBase):
+    question_type = "free_text"
+    model = "gpt-4-1106-preview"
+    default_instructions = textwrap.dedent(
+        """\
+        You are being asked the following question: {{question_text}}
+        Return a valid JSON formatted like this: 
+        {"answer": "<put free text answer here>"}
+        """
+    )
+
+
+get_classes = RegisterPromptsMeta.get_classes
+
+
+if __name__ == "__main__":
+    # q = QuestionInstuctions()
+    d = RegisterPromptsMeta._lookup
+    print(d)
+    get_classes(component_type="question_instructions")

--- a/edsl/questions/AnswerValidatorMixin.py
+++ b/edsl/questions/AnswerValidatorMixin.py
@@ -39,7 +39,8 @@ class AnswerValidatorMixin:
         """Checks that the value of a key is of the specified type"""
         if not isinstance(answer.get(key), of_type):
             raise QuestionAnswerValidationError(
-                f"Answer key '{key}' must be of type {of_type.__name__} (got {answer.get(key)})."
+                f"""Answer key '{key}' must be of type {of_type.__name__}; 
+                (got {answer.get(key)}) which is of type {type(answer.get(key))}."""
             )
 
     def validate_answer_key_value_numeric(

--- a/edsl/questions/Question.py
+++ b/edsl/questions/Question.py
@@ -140,48 +140,6 @@ class Question(ABC, AnswerValidatorMixin, metaclass=RegisterQuestionsMeta):
 
         return compose_questions(self, other_question)
 
-    ############################
-    # LLM methods
-    ############################
-    @staticmethod
-    def scenario_render(text: str, scenario_dict: dict[str, Any]) -> str:
-        """
-        Replaces the variables in the question text with the values from the scenario.
-        - We allow nesting, and hence we may need to do this many times. There is a nesting limit of 100.
-        """
-        t = text
-        MAX_NESTING = 100
-        counter = 0
-        while True:
-            counter += 1
-            new_t = Template(t).render(scenario_dict)
-            if new_t == t:
-                break
-            t = new_t
-            if counter > MAX_NESTING:
-                raise QuestionScenarioRenderError(
-                    "Too much nesting - you created an infnite loop here, pal"
-                )
-
-        return new_t
-
-    def get_prompt(self, scenario=None) -> Prompt:
-        """Shows which prompt should be used with the LLM for this question.
-        It extracts the question attributes from the instantiated question data model.
-        """
-        scenario = scenario or {}
-        template = Template(self.instructions)
-        template_with_attributes = template.render(self.data)
-        env = Environment()
-        ast = env.parse(template_with_attributes)
-        undeclared_variables = meta.find_undeclared_variables(ast)
-        if any([v not in scenario for v in undeclared_variables]):
-            raise QuestionScenarioRenderError(
-                f"Scenario is missing variables: {undeclared_variables}"
-            )
-        prompt = self.scenario_render(template_with_attributes, scenario)
-        return Prompt(prompt)
-
     @abstractmethod
     def validate_answer(self, answer: dict[str, str]):
         pass

--- a/edsl/questions/Question.py
+++ b/edsl/questions/Question.py
@@ -47,11 +47,6 @@ class RegisterQuestionsMeta(ABCMeta):
         return d
 
 
-# q2c = RegisterQuestionsMeta.question_names_to_classes()
-# get_question_class = lambda question_type: q2c.get(question_type)
-# from edsl.questions.question_registry import get_question_class
-
-
 class Question(ABC, AnswerValidatorMixin, metaclass=RegisterQuestionsMeta):
     """
     ABC for something.

--- a/edsl/questions/Question.py
+++ b/edsl/questions/Question.py
@@ -57,7 +57,6 @@ class Question(ABC, AnswerValidatorMixin, metaclass=RegisterQuestionsMeta):
     question_name: str = QuestionNameDescriptor()
     question_text: str = QuestionTextDescriptor()
     short_names_dict: dict[str, str] = ShortNamesDictDescriptor()
-    instructions: str = InstructionsDescriptor()
 
     @property
     def data(self) -> dict:

--- a/edsl/questions/QuestionBudget.py
+++ b/edsl/questions/QuestionBudget.py
@@ -28,24 +28,6 @@ class QuestionBudget(Question):
     question_type = "budget"
     budget_sum: int = IntegerDescriptor(none_allowed=False)
     question_options: list[str] = QuestionOptionsDescriptor()
-    default_instructions = textwrap.dedent(
-        """\
-        You are being asked the following question: {{question_text}}
-        The options are 
-        {% for option in question_options %}
-        {{ loop.index0 }}: {{option}}
-        {% endfor %}                       
-        Return a valid JSON formatted as follows, with a dictionary for your "answer"
-        where the keys are the option numbers and the values are the amounts you want 
-        to allocate to the options, and the sum of the values is {{budget_sum}}:
-        {"answer": {<put dict of option numbers and allocation amounts here>},
-        "comment": "<put explanation here>"}
-        Example response for a budget of 100 and 4 options: 
-        {"answer": {"0": 25, "1": 25, "2": 25, "3": 25},
-        "comment": "I allocated 25 to each option."}
-        There must be an allocation listed for each item (including 0).
-        """
-    )
 
     def __init__(
         self,
@@ -54,14 +36,12 @@ class QuestionBudget(Question):
         question_options: list[str],
         budget_sum: int,
         short_names_dict: Optional[dict[str, str]] = None,
-        instructions: Optional[str] = None,
     ):
         self.question_name = question_name
         self.question_text = question_text
         self.question_options = question_options
         self.budget_sum = budget_sum
         self.short_names_dict = short_names_dict or {}
-        self.instructions = instructions
 
     ################
     # Answer methods
@@ -130,7 +110,6 @@ def main():
     q.question_options
     q.question_name
     q.short_names_dict
-    q.instructions
     # validate an answer
     q.validate_answer(
         {"answer": {0: 100, 1: 0, 2: 0, 3: 0}, "comment": "I like custard"}

--- a/edsl/questions/QuestionBudget.py
+++ b/edsl/questions/QuestionBudget.py
@@ -61,7 +61,7 @@ class QuestionBudget(Question):
         self.question_options = question_options
         self.budget_sum = budget_sum
         self.short_names_dict = short_names_dict or {}
-        self.instructions = instructions or self.default_instructions
+        self.instructions = instructions
 
     ################
     # Answer methods

--- a/edsl/questions/QuestionCheckBox.py
+++ b/edsl/questions/QuestionCheckBox.py
@@ -34,27 +34,6 @@ class QuestionCheckBox(Question):
     question_options: list[str] = QuestionOptionsDescriptor()
     min_selections = IntegerDescriptor(none_allowed=True)
     max_selections = IntegerDescriptor(none_allowed=True)
-    default_instructions = textwrap.dedent(
-        """\
-        You are being asked the following question: {{question_text}}
-        The options are 
-        {% for option in question_options %}
-        {{ loop.index0 }}: {{option}}
-        {% endfor %}                       
-        Return a valid JSON formatted like this, selecting only the number of the option: 
-        {"answer": [<put comma-separated list of answer codes here>], "comment": "<put explanation here>"}
-        {% if min_selections != None and max_selections != None and min_selections == max_selections %}
-        You must select exactly {{min_selections}} options.
-        {% elif min_selections != None and max_selections != None %}
-        Minimum number of options that must be selected: {{min_selections}}.      
-        Maximum number of options that must be selected: {{max_selections}}.
-        {% elif min_selections != None %}
-        Minimum number of options that must be selected: {{min_selections}}.      
-        {% elif max_selections != None %}
-        Maximum number of options that must be selected: {{max_selections}}.      
-        {% endif %}        
-        """
-    )
 
     def __init__(
         self,
@@ -64,7 +43,6 @@ class QuestionCheckBox(Question):
         min_selections: Optional[int] = None,
         max_selections: Optional[int] = None,
         short_names_dict: Optional[dict[str, str]] = None,
-        instructions: Optional[str] = None,
     ):
         self.question_name = question_name
         self.question_text = question_text
@@ -72,7 +50,6 @@ class QuestionCheckBox(Question):
         self.max_selections = max_selections
         self.question_options = question_options
         self.short_names_dict = short_names_dict or dict()
-        self.instructions = instructions
 
     ################
     # Answer methods
@@ -147,7 +124,6 @@ def main():
     q.question_options
     q.question_name
     q.short_names_dict
-    q.instructions
     # validate an answer
     q.validate_answer({"answer": [1, 2], "comment": "I like custard"})
     # translate answer code

--- a/edsl/questions/QuestionCheckBox.py
+++ b/edsl/questions/QuestionCheckBox.py
@@ -72,7 +72,7 @@ class QuestionCheckBox(Question):
         self.max_selections = max_selections
         self.question_options = question_options
         self.short_names_dict = short_names_dict or dict()
-        self.instructions = instructions or self.default_instructions
+        self.instructions = instructions
 
     ################
     # Answer methods

--- a/edsl/questions/QuestionExtract.py
+++ b/edsl/questions/QuestionExtract.py
@@ -25,29 +25,16 @@ class QuestionExtract(Question):
 
     question_type = "extract"
     answer_template: dict[str, Any] = AnswerTemplateDescriptor()
-    default_instructions = textwrap.dedent(
-        """\
-        You are given the following input: "{{question_text}}".
-        Create an ANSWER should be formatted like this: "{{ answer_template }}",
-        and it should have the same keys but values extracted from the input.
-        If the value of a key is not present in the input, fill with "null".
-        Return a valid JSON formatted like this: 
-        {"answer": <put your ANSWER here>}
-        ONLY RETURN THE JSON, AND NOTHING ELSE.
-        """
-    )
 
     def __init__(
         self,
         question_text: str,
         answer_template: dict[str, Any],
         question_name: str,
-        instructions: Optional[str] = None,
     ):
         self.question_name = question_name
         self.question_text = question_text
         self.answer_template = answer_template
-        self.instructions = instructions or self.default_instructions
 
     ################
     # Answer methods
@@ -88,11 +75,8 @@ def main():
     q = QuestionExtract.example()
     q.question_text
     q.question_name
-    q.instructions
     q.answer_template
-    # validate an answer
     q.validate_answer({"answer": {"name": "Moby", "profession": "truck driver"}})
-    # translate answer code
     q.translate_answer_code_to_answer(
         {"answer": {"name": "Moby", "profession": "truck driver"}}
     )

--- a/edsl/questions/QuestionExtract.py
+++ b/edsl/questions/QuestionExtract.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import json
 import random
 import textwrap
 from typing import Any, Optional
@@ -42,11 +43,13 @@ class QuestionExtract(Question):
     def validate_answer(self, answer: Any) -> dict[str, Any]:
         self.validate_answer_template_basic(answer)
         self.validate_answer_key_value(answer, "answer", dict)
+        # self.validate_answer_key_value(answer, "answer", str)
         self.validate_answer_extract(answer)
         return answer
 
     def translate_answer_code_to_answer(self, answer, scenario: Scenario = None):
         """Returns the answer in a human-readable format"""
+        answer["answer"] = json.loads(answer["answer"])
         return answer
 
     def simulate_answer(self, human_readable: bool = True) -> dict[str, str]:

--- a/edsl/questions/QuestionFreeText.py
+++ b/edsl/questions/QuestionFreeText.py
@@ -43,7 +43,7 @@ class QuestionFreeText(Question):
         self.question_text = question_text
         self.question_name = question_name
         self.allow_nonresponse = allow_nonresponse or False
-        self.instructions = instructions or self.default_instructions
+        self.instructions = instructions
 
     ################
     # Answer methods

--- a/edsl/questions/QuestionFunctional.py
+++ b/edsl/questions/QuestionFunctional.py
@@ -54,3 +54,16 @@ class QuestionFunctional(Question):
     def simulate_answer(self, human_readable=True) -> dict[str, str]:
         """Required by Question, but not used by QuestionFunctional"""
         raise NotImplementedError
+
+    @classmethod
+    def example(cls):
+        """Required by Question, but not used by QuestionFunctional"""
+
+        silly_function = lambda scenario, agent_traits: scenario.get(
+            "a", 1
+        ) + scenario.get("b", 2)
+        return cls(
+            question_name="add_two_numbers",
+            question_text="functional",
+            func=silly_function,
+        )

--- a/edsl/questions/QuestionList.py
+++ b/edsl/questions/QuestionList.py
@@ -30,32 +30,16 @@ class QuestionList(Question):
     question_type = "list"
     max_list_items: int = IntegerOrNoneDescriptor()
     allow_nonresponse: bool = AllowNonresponseDescriptor()
-    default_instructions = textwrap.dedent(
-        """\
-        {{question_text}}
-
-        Your response should be only a valid JSON of the following format:
-        {
-            "answer": <list of comma-separated words or phrases >, 
-            "comment": "<put comment here>"
-        }
-        {% if max_list_items is not none %}
-        The list must not contain more than {{ max_list_items }} items.
-        {% endif %}                                           
-    """
-    )
 
     def __init__(
         self,
         question_text: str,
         question_name: str,
         allow_nonresponse: Optional[bool] = None,
-        instructions: Optional[str] = None,
         max_list_items: Optional[int] = None,
     ):
         self.question_text = question_text
         self.question_name = question_name
-        self.instructions = instructions
         self.allow_nonresponse = allow_nonresponse or False
         self.max_list_items = max_list_items
 
@@ -99,7 +83,6 @@ def main():
     q.question_name
     q.allow_nonresponse
     q.max_list_items
-    q.instructions
     # validate an answer
     q.validate_answer({"answer": ["pasta", "garlic", "oil", "parmesan"]})
     # translate answer code

--- a/edsl/questions/QuestionList.py
+++ b/edsl/questions/QuestionList.py
@@ -55,7 +55,7 @@ class QuestionList(Question):
     ):
         self.question_text = question_text
         self.question_name = question_name
-        self.instructions = instructions or self.default_instructions
+        self.instructions = instructions
         self.allow_nonresponse = allow_nonresponse or False
         self.max_list_items = max_list_items
 

--- a/edsl/questions/QuestionMultipleChoice.py
+++ b/edsl/questions/QuestionMultipleChoice.py
@@ -28,18 +28,6 @@ class QuestionMultipleChoice(Question):
     question_type = "multiple_choice"
     purpose = "When options are known and limited"
     question_options: list[str] = QuestionOptionsDescriptor()
-    # default_instructions = textwrap.dedent(
-    #     """\
-    #     You are being asked the following question: {{question_text}}
-    #     The options are
-    #     {% for option in question_options %}
-    #     {{ loop.index0 }}: {{option}}
-    #     {% endfor %}
-    #     Return a valid JSON formatted like this, selecting only the number of the option:
-    #     {"answer": <put answer code here>, "comment": "<put explanation here>"}
-    #     Only 1 option may be selected.
-    #     """
-    # )
 
     def __init__(
         self,
@@ -47,19 +35,11 @@ class QuestionMultipleChoice(Question):
         question_options: list[str],
         question_name: str,
         short_names_dict: Optional[dict[str, str]] = None,
-        instructions: Optional[str] = None,
     ):
         self.question_text = question_text
         self.question_options = question_options
         self.question_name = question_name
         self.short_names_dict = short_names_dict or dict()
-
-        ## Instruction priority:
-        ## 1) instructions passed in (will include in serialization)
-        ## 2) instructions from prompt_registry
-        ## 3) default instructions
-
-        self.instructions = instructions
 
     ################
     # Answer methods
@@ -114,7 +94,6 @@ def main():
     q.question_options
     q.question_name
     q.short_names_dict
-    q.instructions
     # validate an answer
     q.validate_answer({"answer": 0, "comment": "I like custard"})
     # translate answer code

--- a/edsl/questions/QuestionMultipleChoice.py
+++ b/edsl/questions/QuestionMultipleChoice.py
@@ -28,18 +28,18 @@ class QuestionMultipleChoice(Question):
     question_type = "multiple_choice"
     purpose = "When options are known and limited"
     question_options: list[str] = QuestionOptionsDescriptor()
-    default_instructions = textwrap.dedent(
-        """\
-        You are being asked the following question: {{question_text}}
-        The options are 
-        {% for option in question_options %}
-        {{ loop.index0 }}: {{option}}
-        {% endfor %}                       
-        Return a valid JSON formatted like this, selecting only the number of the option: 
-        {"answer": <put answer code here>, "comment": "<put explanation here>"}
-        Only 1 option may be selected.
-        """
-    )
+    # default_instructions = textwrap.dedent(
+    #     """\
+    #     You are being asked the following question: {{question_text}}
+    #     The options are
+    #     {% for option in question_options %}
+    #     {{ loop.index0 }}: {{option}}
+    #     {% endfor %}
+    #     Return a valid JSON formatted like this, selecting only the number of the option:
+    #     {"answer": <put answer code here>, "comment": "<put explanation here>"}
+    #     Only 1 option may be selected.
+    #     """
+    # )
 
     def __init__(
         self,
@@ -53,7 +53,13 @@ class QuestionMultipleChoice(Question):
         self.question_options = question_options
         self.question_name = question_name
         self.short_names_dict = short_names_dict or dict()
-        self.instructions = instructions or self.default_instructions
+
+        ## Instruction priority:
+        ## 1) instructions passed in (will include in serialization)
+        ## 2) instructions from prompt_registry
+        ## 3) default instructions
+
+        self.instructions = instructions
 
     ################
     # Answer methods

--- a/edsl/questions/QuestionNumerical.py
+++ b/edsl/questions/QuestionNumerical.py
@@ -29,29 +29,6 @@ class QuestionNumerical(Question):
     question_type = "numerical"
     min_value: Optional[float] = NumericalOrNoneDescriptor()
     max_value: Optional[float] = NumericalOrNoneDescriptor()
-    default_instructions = textwrap.dedent(
-        """\
-        You are being asked a question that requires a numerical response 
-        in the form of an integer or decimal (e.g., -12, 0, 1, 2, 3.45, ...).
-        Your response must be in the following format:
-        {"answer": "<your numerical answer here>", "comment": "<your explanation here"}
-        You must only include an integer or decimal in the quoted "answer" part of your response. 
-        Here is an example of a valid response:
-        {"answer": "100", "comment": "This is my explanation..."}
-        Here is an example of a response that is invalid because the "answer" includes words:
-        {"answer": "I don't know.", "comment": "This is my explanation..."}
-        If your response is equivalent to zero, your formatted response should look like this:
-        {"answer": "0", "comment": "This is my explanation..."}
-        
-        You are being asked the following question: {{question_text}}
-        {% if min_value is not none %}
-        Minimum answer value: {{min_value}}
-        {% endif %}
-        {% if max_value is not none %}
-        Maximum answer value: {{max_value}}
-        {% endif %}
-        """
-    )
 
     def __init__(
         self,
@@ -59,13 +36,11 @@ class QuestionNumerical(Question):
         question_text: str,
         min_value: Optional[Union[int, float]] = None,
         max_value: Optional[Union[int, float]] = None,
-        instructions: Optional[str] = None,
     ):
         self.question_name = question_name
         self.question_text = question_text
         self.min_value = min_value
         self.max_value = max_value
-        self.instructions = instructions
 
     ################
     # Answer methods
@@ -110,7 +85,6 @@ def main():
     q.question_text
     q.min_value
     q.max_value
-    q.instructions
     # validate an answer
     q.validate_answer({"answer": 1, "comment": "I like custard"})
     # translate answer code

--- a/edsl/questions/QuestionNumerical.py
+++ b/edsl/questions/QuestionNumerical.py
@@ -65,7 +65,7 @@ class QuestionNumerical(Question):
         self.question_text = question_text
         self.min_value = min_value
         self.max_value = max_value
-        self.instructions = instructions or self.default_instructions
+        self.instructions = instructions
 
     ################
     # Answer methods

--- a/edsl/questions/QuestionRank.py
+++ b/edsl/questions/QuestionRank.py
@@ -59,7 +59,7 @@ class QuestionRank(Question):
         self.question_name = question_name
         self.question_text = question_text
         self.question_options = question_options
-        self.instructions = instructions or self.default_instructions
+        self.instructions = instructions
         self.short_names_dict = short_names_dict or dict()
         self.num_selections = num_selections or len(question_options)
 

--- a/edsl/questions/QuestionRank.py
+++ b/edsl/questions/QuestionRank.py
@@ -33,19 +33,6 @@ class QuestionRank(Question):
     question_type = "rank"
     question_options: list[str] = QuestionOptionsDescriptor()
     num_selections = NumSelectionsDescriptor()
-    default_instructions = textwrap.dedent(
-        """\
-        You are being asked the following question: {{question_text}}
-        The options are 
-        {% for option in question_options %}
-        {{ loop.index0 }}: {{option}}
-        {% endfor %}                       
-        Return a valid JSON formatted like this, selecting the numbers of the options in order of preference, 
-        with the most preferred option first, and the least preferred option last: 
-        {"answer": [<put comma-separated list of answer codes here>], "comment": "<put explanation here>"}
-        Exactly {{num_selections}} options must be selected.
-        """
-    )
 
     def __init__(
         self,
@@ -54,12 +41,10 @@ class QuestionRank(Question):
         question_options: list[str],
         num_selections: Optional[int] = None,
         short_names_dict: Optional[dict[str, str]] = None,
-        instructions: Optional[str] = None,
     ):
         self.question_name = question_name
         self.question_text = question_text
         self.question_options = question_options
-        self.instructions = instructions
         self.short_names_dict = short_names_dict or dict()
         self.num_selections = num_selections or len(question_options)
 
@@ -120,7 +105,6 @@ def main():
     q.question_name
     q.question_options
     q.num_selections
-    q.instructions
     # validate an answer
     answer = {"answer": [0, 1], "comment": "I like pizza and pasta."}
     q.validate_answer(answer)

--- a/edsl/questions/derived/QuestionLikertFive.py
+++ b/edsl/questions/derived/QuestionLikertFive.py
@@ -35,14 +35,12 @@ class QuestionLikertFive(QuestionMultipleChoice):
         question_text: str,
         question_options: Optional[list[str]] = likert_options,
         short_names_dict: Optional[dict[str, str]] = None,
-        instructions: Optional[str] = None,
     ):
         super().__init__(
             question_name=question_name,
             question_text=question_text,
             question_options=question_options,
             short_names_dict=short_names_dict,
-            instructions=instructions,
         )
 
     ################
@@ -64,7 +62,6 @@ def main():
     q.question_options
     q.question_name
     q.short_names_dict
-    q.instructions
     # validate an answer
     q.validate_answer({"answer": 0, "comment": "I like custard"})
     # translate answer code

--- a/edsl/questions/derived/QuestionLikertFive.py
+++ b/edsl/questions/derived/QuestionLikertFive.py
@@ -27,6 +27,7 @@ class QuestionLikertFive(QuestionMultipleChoice):
         "Agree",
         "Strongly agree",
     ]
+    # default_instructions = QuestionMultipleChoice.default_instructions
 
     def __init__(
         self,

--- a/edsl/questions/derived/QuestionLinearScale.py
+++ b/edsl/questions/derived/QuestionLinearScale.py
@@ -25,18 +25,6 @@ class QuestionLinearScale(QuestionMultipleChoice):
     question_type = "linear_scale"
     option_labels: Optional[dict[int, str]] = OptionLabelDescriptor()
     question_options = QuestionOptionsDescriptor(linear_scale=True)
-    default_instructions = textwrap.dedent(
-        """\
-        You are being asked the following question: {{question_text}}
-        The options are 
-        {% for option in question_options %}
-        {{ loop.index0 }}: {{option}}
-        {% endfor %}                       
-        Return a valid JSON formatted like this, selecting only the code of the option (codes start at 0): 
-        {"answer": <put answer code here>, "comment": "<put explanation here>"}
-        Only 1 option may be selected.
-        """
-    )
 
     def __init__(
         self,
@@ -44,7 +32,6 @@ class QuestionLinearScale(QuestionMultipleChoice):
         question_options: list[int],
         question_name: str,
         short_names_dict: Optional[dict[str, str]] = None,
-        instructions: Optional[str] = None,
         option_labels: Optional[dict[int, str]] = None,
     ):
         super().__init__(
@@ -52,7 +39,6 @@ class QuestionLinearScale(QuestionMultipleChoice):
             question_options=question_options,
             question_name=question_name,
             short_names_dict=short_names_dict,
-            instructions=instructions,
         )
         self.question_options = question_options
         self.option_labels = option_labels
@@ -78,7 +64,6 @@ def main():
     q.question_options
     q.question_name
     q.short_names_dict
-    q.instructions
     # validate an answer
     q.validate_answer({"answer": 3, "comment": "I like custard"})
     # translate answer code

--- a/edsl/questions/derived/QuestionTopK.py
+++ b/edsl/questions/derived/QuestionTopK.py
@@ -32,7 +32,6 @@ class QuestionTopK(QuestionCheckBox):
         min_selections: int,
         max_selections: int,
         short_names_dict: Optional[dict[str, str]] = None,
-        instructions: Optional[str] = None,
     ):
         super().__init__(
             question_name=question_name,
@@ -41,7 +40,6 @@ class QuestionTopK(QuestionCheckBox):
             short_names_dict=short_names_dict,
             min_selections=min_selections,
             max_selections=max_selections,
-            instructions=instructions,
         )
         if min_selections != max_selections:
             raise QuestionCreationValidationError(
@@ -74,7 +72,6 @@ def main():
     q.question_options
     q.question_name
     q.short_names_dict
-    q.instructions
     # validate an answer
     q.validate_answer({"answer": [0, 3], "comment": "I like custard"})
     # translate answer code

--- a/edsl/questions/derived/QuestionYesNo.py
+++ b/edsl/questions/derived/QuestionYesNo.py
@@ -28,14 +28,12 @@ class QuestionYesNo(QuestionMultipleChoice):
         question_text: str,
         short_names_dict: dict[str, str] = None,
         question_options: list[str] = ["Yes", "No"],
-        instructions: str = None,
     ):
         super().__init__(
             question_name=question_name,
             question_text=question_text,
             question_options=question_options,
             short_names_dict=short_names_dict,
-            instructions=instructions,
         )
         self.question_options = question_options
 
@@ -59,7 +57,6 @@ def main():
     q.question_options
     q.question_name
     q.short_names_dict
-    q.instructions
     # validate an answer
     q.validate_answer({"answer": 0, "comment": "I like custard"})
     # translate answer code

--- a/edsl/results/Result.py
+++ b/edsl/results/Result.py
@@ -20,6 +20,7 @@ class Result(UserDict):
         model: Type[LanguageModel],
         iteration: int,
         answer: str,
+        prompts: dict[str, str] = None,
     ):
         # initialize the UserDict
         data = {
@@ -28,6 +29,7 @@ class Result(UserDict):
             "model": model,
             "iteration": iteration,
             "answer": answer,
+            "prompts": prompts or {},
         }
         super().__init__(**data)
         # but also store the data as attributes
@@ -36,6 +38,7 @@ class Result(UserDict):
         self.model = model
         self.iteration = iteration
         self.answer = answer
+        self.prompts = prompts or {}
 
     ###############
     # Used in Results
@@ -48,6 +51,7 @@ class Result(UserDict):
             "scenario": self.scenario,
             "model": self.model.parameters | {"model": self.model.model},
             "answer": self.answer,
+            "prompts": self.prompts,
         }
 
     @property
@@ -140,7 +144,8 @@ def main():
         "iteration": 0,
         "answer": {
             "how_feeling": "Bad"
-        }
+        }, 
+        "prompts": {"user_prompt": "How are you feeling today?", "system_prompt": "Answer the question"}
     }
     """
 

--- a/edsl/surveys/MemoryPlan.py
+++ b/edsl/surveys/MemoryPlan.py
@@ -37,11 +37,9 @@ class MemoryPlan(UserDict):
             for question_name in self[focal_question]
         ]
 
-        base_prompt = Prompt(
-            """
+        base_prompt_text = """
         Before the question you are now answering, you already answering the following questions:
         """
-        )
 
         def gen_line(question_text, answer):
             "Returns a line of memory"
@@ -49,7 +47,9 @@ class MemoryPlan(UserDict):
 
         lines = [gen_line(*pair) for pair in q_and_a_pairs]
         if lines:
-            return Prompt(base_prompt + "\n Prior questions and answers:".join(lines))
+            return Prompt(
+                base_prompt_text + "\n Prior questions and answers:".join(lines)
+            )
         else:
             return Prompt("")
 

--- a/integration/test_questions.py
+++ b/integration/test_questions.py
@@ -4,6 +4,7 @@ from edsl.questions.question_registry import get_question_class, QuestionBase
 def test_all_questions():
     ## TODO: Add serialization test
     ## TODO: inspect & delete inputs
+    print(f"The available questions are:{QuestionBase.available()}")
     for question_type in QuestionBase.available():
         print(f"Now running: {question_type}")
         cls = get_question_class(question_type)

--- a/integration/test_questions.py
+++ b/integration/test_questions.py
@@ -1,15 +1,26 @@
+import pytest
 from edsl.questions.question_registry import get_question_class, QuestionBase
 
 
-def test_all_questions():
-    ## TODO: Add serialization test
-    ## TODO: inspect & delete inputs
-    print(f"The available questions are:{QuestionBase.available()}")
-    for question_type in QuestionBase.available():
+class TestAllQuestions:
+    pass
+
+
+def create_test_function(question_type):
+    def test_func(self):
         print(f"Now running: {question_type}")
         cls = get_question_class(question_type)
         try:
             results = cls.example().run()
+            assert results is not None  # or any other assertion as needed
         except Exception as e:
-            print(f"Error running {question_type}: {e}")
-            continue
+            pytest.fail(f"Error running {question_type}: {e}")
+
+    return test_func
+
+
+# Dynamically adding test methods for each question type
+for question_type in QuestionBase.available():
+    test_method_name = f"test_{question_type}"
+    test_method = create_test_function(question_type)
+    setattr(TestAllQuestions, test_method_name, test_method)

--- a/integration/test_questions.py
+++ b/integration/test_questions.py
@@ -1,0 +1,14 @@
+from edsl.questions.question_registry import get_question_class, QuestionBase
+
+
+def test_all_questions():
+    ## TODO: Add serialization test
+    ## TODO: inspect & delete inputs
+    for question_type in QuestionBase.available():
+        print(f"Now running: {question_type}")
+        cls = get_question_class(question_type)
+        try:
+            results = cls.example().run()
+        except Exception as e:
+            print(f"Error running {question_type}: {e}")
+            continue

--- a/tests/questions/test_Question.py
+++ b/tests/questions/test_Question.py
@@ -26,10 +26,10 @@ def test_Question_properties(capsys):
     q = QuestionFreeText(**valid_question)
 
     # Prompt stuff
-    assert q.get_prompt()
+    # assert q.get_prompt()
     q3 = QuestionFreeText(**valid_question_three)
-    with pytest.raises(QuestionScenarioRenderError):
-        q3.get_prompt()
+    # with pytest.raises(QuestionScenarioRenderError):
+    #    q3.get_prompt()
     # assert q.formulate_prompt()
     # with pytest.raises(QuestionScenarioRenderError):
     #     q3.formulate_prompt()

--- a/tests/questions/test_Question.py
+++ b/tests/questions/test_Question.py
@@ -30,9 +30,9 @@ def test_Question_properties(capsys):
     q3 = QuestionFreeText(**valid_question_three)
     with pytest.raises(QuestionScenarioRenderError):
         q3.get_prompt()
-    assert q.formulate_prompt()
-    with pytest.raises(QuestionScenarioRenderError):
-        q3.formulate_prompt()
+    # assert q.formulate_prompt()
+    # with pytest.raises(QuestionScenarioRenderError):
+    #     q3.formulate_prompt()
     curly = valid_question.copy()
     curly["question_text"] = "What is the capital of {country}"
     # make sure that when you initialize curly, it outputs a string that contains "WARNING"

--- a/tests/questions/test_QuestionBudget.py
+++ b/tests/questions/test_QuestionBudget.py
@@ -139,7 +139,6 @@ def test_QuestionBudget_extras():
     """Test QuestionBudget's extra functionalities."""
     q = QuestionBudget(**valid_question)
     # instructions
-    assert "You are being asked" in q.instructions
     # translate
     assert q.translate_answer_code_to_answer({"0": 25, "1": 25, "2": 25, "3": 25}) == [
         {"Pizza": 25},

--- a/tests/questions/test_QuestionCheckbox.py
+++ b/tests/questions/test_QuestionCheckbox.py
@@ -263,9 +263,7 @@ def test_QuestionCheckBox_extras():
     q = QuestionCheckBox(**valid_question)
     # translate_answer_code_to_answer
     assert q.translate_answer_code_to_answer([0, 1], None) == ["Mon", "Tue"]
-    # instructions
-    assert "You are being asked" in q.instructions
-    # simulate_answer
+
     assert q.simulate_answer().keys() == q.simulate_answer(human_readable=True).keys()
     assert q.simulate_answer(human_readable=False)["answer"][0] in range(
         len(q.question_options)

--- a/tests/questions/test_QuestionFreeText.py
+++ b/tests/questions/test_QuestionFreeText.py
@@ -132,7 +132,6 @@ def test_test_QuestionFreeText_extras():
     """Test QuestionFreeText extra functionalities."""
     q = QuestionFreeText(**valid_question)
     # instructions
-    assert "You are being asked" in q.instructions
     # simulate_answer
     simulated_answer = q.simulate_answer()
     assert isinstance(simulated_answer, dict)

--- a/tests/questions/test_QuestionFunctional.py
+++ b/tests/questions/test_QuestionFunctional.py
@@ -25,7 +25,6 @@ def test_QuestionFunctional_construction_from_function():
     assert "question_type" in q.to_dict()
     assert "functional" in q.to_dict()["question_type"]
     # unnecessary methods are not implemented
-    assert q.instructions == ""
     assert q.translate_answer_code_to_answer(None, None) is None
     with pytest.raises(NotImplementedError):
         q.simulate_answer()

--- a/tests/questions/test_QuestionFunctional.py
+++ b/tests/questions/test_QuestionFunctional.py
@@ -134,7 +134,7 @@ def mock_questions_factory():
         mock_results2.select.return_value = ["Large"]
 
         # Mock the get_prompt method for q2
-        q2.get_prompt.return_value = "What is the population of Paris"
+        # q2.get_prompt.return_value = "What is the population of Paris"
 
         return q1, q2
 

--- a/tests/questions/test_QuestionLikertFive.py
+++ b/tests/questions/test_QuestionLikertFive.py
@@ -72,7 +72,4 @@ def test_QuestionLikertFive_extras():
     """Test QuestionFreeText extra functionalities."""
     q = QuestionLikertFive(**valid_question)
     # instructions
-    assert "You are being asked" in q.instructions
-    assert "{{question_text}}" in q.instructions
-    assert "for option in question_options" in q.instructions
     # form elements

--- a/tests/questions/test_QuestionLinearScale.py
+++ b/tests/questions/test_QuestionLinearScale.py
@@ -157,7 +157,6 @@ def test_QuestionLinearScale_extras():
     """Test QuestionFreeText extra functionalities."""
     q = QuestionLinearScale(**valid_question)
     # instructions
-    assert "You are being asked" in q.instructions
     # simulate_answer
     assert q.simulate_answer().keys() == q.simulate_answer(human_readable=True).keys()
     assert q.simulate_answer(human_readable=False)["answer"] in range(

--- a/tests/questions/test_QuestionList.py
+++ b/tests/questions/test_QuestionList.py
@@ -177,7 +177,6 @@ def test_test_QuestionList_extras():
     """Test QuestionList extra functionalities."""
     q = QuestionList(**valid_question)
     # instructions
-    assert "Your response" in q.instructions
     # simulate_answer
     simulated_answer = q.simulate_answer()
     assert isinstance(simulated_answer, dict)

--- a/tests/questions/test_QuestionMultipleChoice.py
+++ b/tests/questions/test_QuestionMultipleChoice.py
@@ -190,7 +190,6 @@ def test_QuestionMultipleChoice_extras():
     """Test QuestionFreeText extra functionalities."""
     q = QuestionMultipleChoice(**valid_question)
     # instructions
-    assert "You are being asked" in q.instructions
     # translate answer code to answer
     assert q.translate_answer_code_to_answer(0, scenario=None) == "OK"
     assert q.translate_answer_code_to_answer(1, scenario=None) == "Bad"

--- a/tests/questions/test_QuestionNumerical.py
+++ b/tests/questions/test_QuestionNumerical.py
@@ -179,7 +179,6 @@ def test_test_QuestionNumerical_extras():
     """Test QuestionNumerical extra functionalities."""
     q = QuestionNumerical(**valid_question)
     # instructions
-    assert "You are being asked a question" in q.instructions
     # simulate_answer
     simulated_answer = q.simulate_answer()
     assert isinstance(simulated_answer, dict)

--- a/tests/questions/test_QuestionRank.py
+++ b/tests/questions/test_QuestionRank.py
@@ -200,7 +200,6 @@ def test_QuestionRank_extras():
     """Test QuestionFreeText extra functionalities."""
     q = QuestionRank(**valid_question)
     # instructions
-    assert "You are being asked" in q.instructions
     # simulate_answer
     assert q.simulate_answer().keys() == q.simulate_answer(human_readable=True).keys()
     assert q.simulate_answer(human_readable=False)["answer"][0] in range(


### PR DESCRIPTION
This is still fairly ugly (I'll clean it up) but this does much to implement Issue #45 suggestions

- All prompt-construction happens in the Invigilator class (which I will move up to to-level of edsl)
- Question prompts are now defined in in `edsl/prompt/Prompt` - the system does a lookup when run

In addition - I added a new integration test that uses the ".example()" method for each question, iterating through all registered questions. We should expand this logic to test serialization / deserialization and so on. 