### PR TITLE
Collection up exceptions & print failures ex-post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,19 @@
 ### Removed
 - Unused files
 - Unused package dependencies
+
+## [0.1.5] - 2023-01-23
+
+### Fixed
+- Improvements in async survey running
+
+## [0.1.6] - 2023-01-24
+
+### Fixed
+- Improvements in async survey running
+
+## [0.1.7] - 2023-01-25
+
+### Fixed
+- Improvements in async survey running
+- Added logging

--- a/edsl/jobs/Interview.py
+++ b/edsl/jobs/Interview.py
@@ -1,34 +1,36 @@
 from __future__ import annotations
 import asyncio
 import logging
-
-# from tenacity import retry, wait_exponential, stop_after_attempt
-from typing import Any, Type, Union, List
+from typing import Any, Type, List
 from edsl.agents import Agent
 from edsl.language_models import LanguageModel
 from edsl.questions import Question
 from edsl.scenarios import Scenario
 from edsl.surveys import Survey
 from edsl.utilities.decorators import sync_wrapper
-
+from edsl.config import Config
 from edsl.data_transfer_models import AgentResponseDict
-
 from edsl.jobs.Answers import Answers
 
-from edsl.config import Config
 
 TIMEOUT = int(Config().API_CALL_TIMEOUT_SEC)
 
-logging.basicConfig(
-    level=logging.INFO,  # Set the logging level
-    format="%(asctime)s - %(name)s - %(levelname)s - %(module)s:%(lineno)d - %(funcName)s - %(message)s",
-    filename="interview.log",
-)
-
+# create logger
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)  # Default level
+logger.setLevel(logging.INFO)
+logger.propagate = False
+# create  file handler
+fh = logging.FileHandler("interview.log")
+fh.setLevel(logging.INFO)
+# add formatter to the handlers
+formatter = logging.Formatter(
+    "%(asctime)s - %(name)s - %(levelname)s - %(module)s:%(lineno)d - %(funcName)s - %(message)s"
+)
+fh.setFormatter(formatter)
+# add handler to logger
+logger.addHandler(fh)
 
-
+# start loggin'
 logger.info("Interview.py loaded")
 
 

--- a/edsl/surveys/DAG.py
+++ b/edsl/surveys/DAG.py
@@ -7,6 +7,13 @@ class DAG(UserDict):
         self.reverse_mapping = self._create_reverse_mapping()
 
     def _create_reverse_mapping(self):
+        """
+        Creates a reverse mapping of the DAG, where the keys are the children and the values are the parents.
+        >>> data = {"a": ["b", "c"], "b": ["d"], "c": [], "d": []}
+        >>> dag = DAG(data)
+        >>> dag._create_reverse_mapping()
+        {'b': {'a'}, 'c': {'a'}, 'd': {'b'}}
+        """
         rev_map = {}
         for key, values in self.data.items():
             for value in values:
@@ -24,3 +31,9 @@ class DAG(UserDict):
 
         dfs(key)
         return children
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ documentation = "https://www.goemeritus.com/getting-started/"
 homepage = "https://www.goemeritus.com/"
 keywords = ["LLM", "social science", "surveys", "user research"]
 license = "MIT"
-name = "edsl"
+name = "edsltest"
 packages = [{include = "edsl"}]
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = "^3.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ documentation = "https://www.goemeritus.com/getting-started/"
 homepage = "https://www.goemeritus.com/"
 keywords = ["LLM", "social science", "surveys", "user research"]
 license = "MIT"
-name = "edsltest"
+name = "edsl"
 packages = [{include = "edsl"}]
 readme = "README.md"
 version = "0.1.7"


### PR DESCRIPTION
This is an important commit & should deal with a lot of the problems where a failure of any tasks derails the process. 

1. Exceptions in asyncio tasks are supressed
2. When they are collection up, any failures are printed to the screen 

TODO: 
1. Tasks have an "exceptions()" bound method we should use but I couldn't get it to work
2. We should also cancel all children that depend on a failed task. TBD. The issue is to do this I'll need to make another pass through the list of tasks. 