### PR TITLE
Testing for Interview module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,9 @@
 ### Fixed
 - Improvements in async survey running
 - Added logging
+
+## [0.1.8] - 2023-01-26
+
+### Fixed
+- Better handling of async failures
+- Fixed bug in survey logic

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test: ## Run tests via pytest
 testpypi: ## Upload package to test pypi
 	[ ! -d dist ] || rm -rf dist
 	poetry build
-	poetry publish -r testpypi
+	poetry publish -r test-pypi 
 	[ ! -d dist ] || rm -rf dist
 
 watch-docs: ## Build and watch documentation.

--- a/Makefile
+++ b/Makefile
@@ -72,5 +72,11 @@ lint: ## Run code linters (flake8, pylint, mypy).
 test: ## Run tests via pytest
 	pytest -x tests
 
+testpypi: ## Upload package to test pypi
+	[ ! -d dist ] || rm -rf dist
+	poetry build
+	poetry publish -r testpypi
+	[ ! -d dist ] || rm -rf dist
+
 watch-docs: ## Build and watch documentation.
 	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/edsl/

--- a/edsl/jobs/Interview.py
+++ b/edsl/jobs/Interview.py
@@ -151,8 +151,8 @@ class Interview:
 
         valid_results = list(self._extract_valid_results(tasks))
 
-        print(f"Total of tasks requested:\t {len(tasks)}")
-        print(f"Number of valid results:\t {len(valid_results)}")
+        logger.info(f"Total of tasks requested:\t {len(tasks)}")
+        logger.info(f"Number of valid results:\t {len(valid_results)}")
         return self.answers, valid_results
 
     conduct_interview = sync_wrapper(async_conduct_interview)

--- a/edsl/jobs/Interview.py
+++ b/edsl/jobs/Interview.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import textwrap
-import traceback
 from collections import UserDict
 from collections import defaultdict
 
@@ -13,7 +12,6 @@ from edsl.questions import Question
 from edsl.scenarios import Scenario
 from edsl.surveys import Survey
 from edsl.utilities.decorators import sync_wrapper
-from edsl.config import Config
 from edsl.data_transfer_models import AgentResponseDict
 from edsl.jobs.Answers import Answers
 from collections import UserList
@@ -37,8 +35,6 @@ class InterviewTimeoutError(InterviewError):
     pass
 
 
-TIMEOUT = int(Config().API_CALL_TIMEOUT_SEC)
-
 # create logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -57,6 +53,10 @@ logger.addHandler(fh)
 # start loggin'
 logger.info("Interview.py loaded")
 
+from edsl.config import Config
+
+TIMEOUT = int(Config().API_CALL_TIMEOUT_SEC)
+
 
 class FailedTask(UserDict):
     def __init__(self, e: Exception = None):
@@ -67,24 +67,6 @@ class FailedTask(UserDict):
             "exception": e,
         }
         super().__init__(data)
-
-
-def async_timeout_handler(timeout):
-    def decorator(func):
-        async def wrapper(*args, **kwargs):
-            try:
-                return await asyncio.wait_for(func(*args, **kwargs), timeout)
-            except asyncio.TimeoutError:
-                raise InterviewTimeoutError(f"Task timed out after {timeout} seconds.")
-                # question = args[1]  # Assuming the first argument is the question
-                # task_name = getattr(question, "question_name", "unknown")
-                # print(f"Task {task_name} timed out after {timeout} seconds.")
-                # logger.error(f"Task {task_name} timed out")
-                # return None
-
-        return wrapper
-
-    return decorator
 
 
 class QuestionTaskCreator(UserList):
@@ -236,6 +218,25 @@ class Interview:
         for dependency in tasks_that_must_be_completed_before:
             create_task.append(dependency)
         return create_task(question, debug)
+
+    def async_timeout_handler(timeout):
+        def decorator(func):
+            async def wrapper(*args, **kwargs):
+                try:
+                    return await asyncio.wait_for(func(*args, **kwargs), timeout)
+                except asyncio.TimeoutError:
+                    raise InterviewTimeoutError(
+                        f"Task timed out after {timeout} seconds."
+                    )
+                    # question = args[1]  # Assuming the first argument is the question
+                    # task_name = getattr(question, "question_name", "unknown")
+                    # print(f"Task {task_name} timed out after {timeout} seconds.")
+                    # logger.error(f"Task {task_name} timed out")
+                    # return None
+
+            return wrapper
+
+        return decorator
 
     @async_timeout_handler(TIMEOUT)
     async def _answer_question_and_record_task(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = "MIT"
 name = "edsl"
 packages = [{include = "edsl"}]
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = "^3.9.1"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -50,10 +50,10 @@ def test_config_store_and_load(test_config):
     assert test_config.OPENAI_API_KEY == MOCK_ENV_VARS["OPENAI_API_KEY"]
     assert os.getenv("OPENAI_API_KEY") == test_config.OPENAI_API_KEY
     # both in the object and in the env for vars that are not given but have default
-    assert test_config.API_CALL_TIMEOUT_SEC == CONFIG_MAP.get(
-        "API_CALL_TIMEOUT_SEC"
-    ).get("default")
-    assert os.getenv("API_CALL_TIMEOUT_SEC") == test_config.API_CALL_TIMEOUT_SEC
+    assert test_config.EMERITUS_API_KEY == CONFIG_MAP.get("EMERITUS_API_KEY").get(
+        "default"
+    )
+    assert os.getenv("EMERITUS_API_KEY") == test_config.EMERITUS_API_KEY
 
 
 def test_config_invalid_var(mock_env):

--- a/tests/jobs/test_Interview.py
+++ b/tests/jobs/test_Interview.py
@@ -1,5 +1,88 @@
-from edsl.jobs.Interview import main
+import pytest
+import asyncio
+from typing import Any
+import os
+
+from edsl.language_models.LanguageModel import LanguageModel
+from edsl.enums import LanguageModelType, InferenceServiceType
+from edsl import Survey
+from edsl.questions import QuestionFreeText
+from httpcore import ConnectionNotAvailable
 
 
-def test_interview_main():
-    main()
+def create_language_model(
+    exception: Exception, fail_at_number: int, never_ending=False
+):
+    class TestLanguageModel(LanguageModel):
+        _model_ = LanguageModelType.TEST.value
+        _parameters_ = {"temperature": 0.5, "use_cache": False}
+        _inference_service_ = InferenceServiceType.TEST.value
+        counter = 0
+
+        async def async_execute_model_call(
+            self, user_prompt: str, system_prompt: str
+        ) -> dict[str, Any]:
+            await asyncio.sleep(0.1)
+            if never_ending:  ## you're not going anywhere buddy
+                await asyncio.sleep(float("inf"))
+            self.counter += 1
+            if self.counter == fail_at_number:
+                if asyncio.iscoroutinefunction(exception):
+                    await exception()
+                else:
+                    raise exception
+            return {"message": """{"answer": "SPAM!"}"""}
+
+        def parse_response(self, raw_response: dict[str, Any]) -> str:
+            return raw_response["message"]
+
+    return TestLanguageModel
+
+
+@pytest.fixture
+def create_survey():
+    def _create_survey(num_questions: int, chained: bool = True):
+        survey = Survey()
+        for i in range(num_questions):
+            q = QuestionFreeText(
+                question_text=f"How are you?", question_name=f"question_{i}"
+            )
+            survey.add_question(q)
+            if i > 0 and chained:
+                survey.add_targeted_memory(f"question_{i}", f"question_{i-1}")
+        return survey
+
+    return _create_survey
+
+
+@pytest.mark.parametrize("fail_at_number, chained", [(6, False), (10, True)])
+def test_handle_model_exceptions(create_survey, fail_at_number, chained):
+    model = create_language_model(ValueError, fail_at_number)()
+    survey = create_survey(num_questions=20, chained=chained)
+    results = survey.by(model).run()
+
+    if not chained:
+        assert results.select(f"answer.question_{fail_at_number - 1}").first() is None
+        assert (
+            results.select(f"answer.question_{fail_at_number + 1}").first() == "SPAM!"
+        )
+    else:
+        assert results[0]["answer"][f"question_{fail_at_number - 1}"] is None
+        assert results[0]["answer"][f"question_{fail_at_number}"] is None
+        # Additional assertions can be added here as needed
+
+
+def test_handle_timeout_exception(create_survey, capsys):
+    ## TODO: We want to shrink the API_TIMEOUT_SEC param for testing purposes.
+    model = create_language_model(ValueError, 3, never_ending=True)()
+    survey = create_survey(num_questions=5, chained=False)
+    results = survey.by(model).run()
+    captured = capsys.readouterr()
+    assert (
+        "WARNING: At least one question in the survey was not answered." in captured.out
+    )
+    assert "Task `question_0` failed with `InterviewTimeoutError" in captured.out
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -6,5 +6,6 @@ env =
     DEEP_INFRA_API_KEY=a_fake_key
     EDSL_DATABASE_PATH=sqlite:///:memory:
     EDSL_TESTING=True
+    API_CALL_TIMEOUT_SEC=1
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
Not amazing but a start - in a nutshell it creates models that will fail in some way and then checks to see if they do fail that way. 

re: API timeout - the test is slow because the last test in `tests/jobs/test_Interview.py` is using our production API Timeout. Can you re-factor to say 3 seconds or so? 