### PR TITLE
Fixes prompt alignment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,15 @@
 ### Removed
 - The package no longer supports a report extras option.
 - Fixed a bug in EndofSurvey
+
+## [0.1.11] - 2023-02-xx
+
+### Added
+- 
+
+### Fixed
+- Question options can now be 1 character long or more (down from 2 characters)
+- Fixed a bug where prompts displayed were incorrect (prompts sent were correct)
+
+### Removed
+- 

--- a/edsl/agents/Agent.py
+++ b/edsl/agents/Agent.py
@@ -126,7 +126,7 @@ class Agent(Base):
         bound_method = types.MethodType(method, self)
         setattr(self, "answer_question_directly", bound_method)
 
-    async def async_answer_question(
+    def create_invigilator(
         self,
         question: Question,
         scenario: Optional[Scenario] = None,
@@ -135,17 +135,36 @@ class Agent(Base):
         memory_plan: Optional[MemoryPlan] = None,
         current_answers: Optional[dict] = None,
     ):
-        """
-        This is a function where an agent returns an answer to a particular question.
-        However, there are several different ways an agent can answer a question, so the
-        actual functionality is delegated to an Invigilator object.
-        """
         self.current_question = question
         # model = model or LanguageModelOpenAIThreeFiveTurbo(use_cache=True)
         model = model or Model("gpt-3.5-turbo", use_cache=True)
         scenario = scenario or Scenario()
         invigilator = self._create_invigilator(
             question, scenario, model, debug, memory_plan, current_answers
+        )
+        return invigilator
+
+    async def async_answer_question(
+        self,
+        question: Question,
+        scenario: Optional[Scenario] = None,
+        model: Optional[LanguageModel] = None,
+        debug: bool = False,
+        memory_plan: Optional[MemoryPlan] = None,
+        current_answers: Optional[dict] = None,
+    ) -> AgentResponseDict:
+        """
+        This is a function where an agent returns an answer to a particular question.
+        However, there are several different ways an agent can answer a question, so the
+        actual functionality is delegated to an Invigilator object.
+        """
+        invigilator = self.create_invigilator(
+            question=question,
+            scenario=scenario,
+            model=model,
+            debug=debug,
+            memory_plan=memory_plan,
+            current_answers=current_answers,
         )
         response: AgentResponseDict = await invigilator.async_answer_question()
         return response

--- a/edsl/data_transfer_models.py
+++ b/edsl/data_transfer_models.py
@@ -2,5 +2,12 @@ from collections import UserDict
 
 
 class AgentResponseDict(UserDict):
-    def __init__(self, answer, comment, prompts):
-        super().__init__({"answer": answer, "comment": comment, "prompts": prompts})
+    def __init__(self, *, question_name, answer, comment, prompts):
+        super().__init__(
+            {
+                "answer": answer,
+                "comment": comment,
+                "question_name": question_name,
+                "prompts": prompts,
+            }
+        )

--- a/edsl/exceptions/agents.py
+++ b/edsl/exceptions/agents.py
@@ -24,3 +24,9 @@ class AgentLacksLLMError(AgentErrors):
 
 class AgentRespondedWithBadJSONError(AgentErrors):
     pass
+
+
+class FailedTaskException(Exception):
+    def __init__(self, message, agent_response_dict):
+        super().__init__(message)
+        self.agent_response_dict = agent_response_dict

--- a/edsl/jobs/runners/JobsRunnerAsyncio.py
+++ b/edsl/jobs/runners/JobsRunnerAsyncio.py
@@ -27,38 +27,43 @@ class JobsRunnerAsyncio(JobsRunner):
 
     async def _interview_task(self, interview, i, debug):
         # Assuming async_conduct_interview and Result are defined and work asynchronously
-        answer, prompt_data = await interview.async_conduct_interview(debug=debug)
-        user_prompts, system_prompts = self._get_prompts(answer, prompt_data)
+        answer, valid_results = await interview.async_conduct_interview(debug=debug)
+
+        answer_key_names = {k for k in set(answer.keys()) if not k.endswith("_comment")}
+
+        assert len(valid_results) == len(answer_key_names)
+
+        question_name_to_prompts = dict({})
+        for result in valid_results:
+            question_name = result["question_name"]
+            question_name_to_prompts[question_name] = {
+                "user_prompt": result["prompts"]["user_prompt"],
+                "system_prompt": result["prompts"]["system_prompt"],
+            }
+
+        prompt_dictionary = {}
+        for answer_key_name in answer_key_names:
+            prompt_dictionary[
+                answer_key_name + "_user_prompt"
+            ] = question_name_to_prompts[answer_key_name]["user_prompt"]
+            prompt_dictionary[
+                answer_key_name + "_system_prompt"
+            ] = question_name_to_prompts[answer_key_name]["system_prompt"]
+
         # breakpoint()
+        #        user_prompt = [for key in answer_key_names]
+        # user_prompts, system_prompts = self._get_prompts(answer, prompt_data)
+        # breakpoint()
+
         result = Result(
             agent=interview.agent,
             scenario=interview.scenario,
             model=interview.model,
             iteration=i,
             answer=answer,
-            prompt=user_prompts | system_prompts,
+            prompt=prompt_dictionary,
         )
         return result
-
-    def _get_prompts(self, answer, prompt_data):
-        """Gets the prompts used in the survey."""
-        answer_names = [k for k in answer.keys() if not k.endswith("_comment")]
-        try:
-            user_prompts = [result["prompts"]["user_prompt"] for result in prompt_data]
-            system_prompts = [
-                result["prompts"]["system_prompt"] for result in prompt_data
-            ]
-        except KeyError:
-            user_prompts = [None] * len(answer_names)
-            system_prompts = [None] * len(answer_names)
-
-        def append_type(prompts, prompt_type):
-            return {k + "_" + prompt_type: v for k, v in zip(answer_names, prompts)}
-
-        user_prompts = append_type(user_prompts, "user_prompt")
-        system_prompts = append_type(system_prompts, "system_prompt")
-
-        return user_prompts, system_prompts
 
     @jupyter_nb_handler
     def run(

--- a/edsl/questions/AnswerValidatorMixin.py
+++ b/edsl/questions/AnswerValidatorMixin.py
@@ -39,7 +39,7 @@ class AnswerValidatorMixin:
         """Checks that the value of a key is of the specified type"""
         if not isinstance(answer.get(key), of_type):
             raise QuestionAnswerValidationError(
-                f"""Answer key '{key}' must be of type {of_type.__name__}; 
+                f"""Answer key '{key}' must be of type {of_type.__name__};
                 (got {answer.get(key)}) which is of type {type(answer.get(key))}."""
             )
 

--- a/edsl/questions/descriptors.py
+++ b/edsl/questions/descriptors.py
@@ -256,12 +256,12 @@ class QuestionOptionsDescriptor(BaseDescriptor):
                 )
             if not all(
                 [
-                    len(option) > 1 and len(option) < Settings.MAX_OPTION_LENGTH
+                    len(option) >= 1 and len(option) < Settings.MAX_OPTION_LENGTH
                     for option in value
                 ]
             ):
                 raise QuestionCreationValidationError(
-                    f"All question options must be at least 2 characters long but less than {Settings.MAX_OPTION_LENGTH} characters long (got {value})."
+                    f"All question options must be at least 1 character long but less than {Settings.MAX_OPTION_LENGTH} characters long (got {value})."
                 )
 
         if hasattr(instance, "min_selections") and instance.min_selections != None:

--- a/integration/test_langugage_model.py
+++ b/integration/test_langugage_model.py
@@ -1,0 +1,26 @@
+import asyncio
+from typing import Any, Coroutine
+
+from edsl.language_models import LanguageModel
+
+
+class DummyModel(LanguageModel):
+    model_ = "dummy"
+
+    async def async_execute_model_call(self, *args, **kwargs) -> Coroutine:
+        await asyncio.sleep(0)
+        data = {"content": """{"answer": "SPAM", "comment": "This is a comment"}"""}
+        return data
+
+    def parse_response(self, raw_response: dict[str, Any]) -> str:
+        return raw_response["content"]
+
+
+def test_lm():
+    lm = DummyModel(use_cache=False)
+    lm.model = "dummy"
+    lm.parameters = {}
+    assert lm.get_response(user_prompt="blah", system_prompt="blah") == {
+        "answer": "SPAM",
+        "comment": "This is a comment",
+    }

--- a/tests/jobs/test_Interview.py
+++ b/tests/jobs/test_Interview.py
@@ -69,7 +69,6 @@ def test_handle_model_exceptions(create_survey, fail_at_number, chained):
     else:
         assert results[0]["answer"][f"question_{fail_at_number - 1}"] is None
         assert results[0]["answer"][f"question_{fail_at_number}"] is None
-        # Additional assertions can be added here as needed
 
 
 def test_handle_timeout_exception(create_survey, capsys):


### PR DESCRIPTION
This turned out to be a bigger deal to fix than I thought. The core problem was that I was implicitly relying on some dictionaries being sorted (dumb) that could be used to match up a question and the associated prompts used. I fixed that by including this prompt information right "next to" the answer in one dictionary. However, this doesn't work if the task fails---it's not easy to extract info from a failed asyncio task. So what I did instead was essentially create the asyncio tasks, but also list of non-async tasks (of `Invigilator` objects) that I rely on in case the task fails. 

Generally, this task-running code is not well organized and hard to follow, esp. since it has like 4 stacks (for good reasons, but I should ref-factor) as I think right now it would basically be impossible for anyone else to work on. Not good. I'm starting to diagram it all a bit here: 
 
https://docs.google.com/presentation/d/1Y4kYDzaKLmVjiu0neyQIxa2AssUUvYtJ7-TiS6m4WRM/edit?usp=sharing 

Anyway, it 'works" but I need to spend more time here. 